### PR TITLE
[#23] Refactored to remove deprecated function

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -2,11 +2,11 @@ package codec
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
 
-	"oss.nandlabs.io/golly/errutils"
 	"oss.nandlabs.io/golly/textutils"
 )
 
@@ -151,7 +151,7 @@ func Get(contentType string, options map[string]interface{}) (c Codec, err error
 			bc.readerWriter = &yamlRW{options: options}
 		}
 	default:
-		err = errutils.FmtError("Unsupported contentType %s", contentType)
+		err = fmt.Errorf("Unsupported contentType %s", contentType)
 	}
 
 	if err == nil {

--- a/errutils/errutils.go
+++ b/errutils/errutils.go
@@ -2,33 +2,10 @@ package errutils
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"oss.nandlabs.io/golly/textutils"
 )
-
-// FmtError formats an error message using a format string and optional values,
-// and returns it as an error object.
-//
-// It takes a format string f and variadic arguments v, and uses them to construct
-// the error message by calling fmt.Sprintf function. The resulting error message
-// is then wrapped into an error object using errors.New.
-//
-// Example:
-//
-//	err := FmtError("Invalid input: %s", userInput)
-//	if err != nil {
-//		log.Println(err)
-//	}
-//
-// Deprecated: In favour of fmt.Errorf(...) instead
-// @param f The format string specifying the error message.
-// @param v Optional values to be inserted into the format string.
-// @returns An error object containing the formatted error message.
-func FmtError(f string, v ...any) error {
-	return errors.New(fmt.Sprintf(f, v...))
-}
 
 type MultiError struct {
 	errs []error

--- a/errutils/errutils_test.go
+++ b/errutils/errutils_test.go
@@ -6,16 +6,6 @@ import (
 	"testing"
 )
 
-// TestFmtError tests the FmtError function
-func TestFmtError(t *testing.T) {
-	t.Run("Testing execution of FmtError", func(t *testing.T) {
-		err := FmtError("testing error")
-		if err == nil {
-			t.Errorf("error not created")
-		}
-	})
-}
-
 // TestMultiError_Add tests the Add function of MultiError
 func TestMultiError_Add(t *testing.T) {
 	t.Run("Testing execution of MultiError_Add", func(t *testing.T) {

--- a/rest/request.go
+++ b/rest/request.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 	"strings"
 
 	"oss.nandlabs.io/golly/codec"
-	"oss.nandlabs.io/golly/errutils"
 	"oss.nandlabs.io/golly/ioutils"
 	"oss.nandlabs.io/golly/textutils"
 )
@@ -177,7 +177,7 @@ func (r *Request) toHttpRequest() (httpReq *http.Request, err error) {
 					if v, ok := r.pathParams[key]; ok {
 						pathValues[i] = v
 					} else {
-						err = errutils.FmtError("Path param with name %s is not set in the request ", key)
+						err = fmt.Errorf("Path param with name %s is not set in the request ", key)
 						break
 					}
 				}

--- a/rest/response.go
+++ b/rest/response.go
@@ -1,10 +1,10 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 
 	"oss.nandlabs.io/golly/codec"
-	"oss.nandlabs.io/golly/errutils"
 	"oss.nandlabs.io/golly/ioutils"
 )
 
@@ -21,7 +21,7 @@ func (r *Response) IsSuccess() bool {
 // GetError gets the error with status code and value
 func (r *Response) GetError() (err error) {
 	if !r.IsSuccess() {
-		err = errutils.FmtError("Server responded with status code %d and status text %s",
+		err = fmt.Errorf("Server responded with status code %d and status text %s",
 			r.raw.StatusCode, r.raw.Status)
 	}
 	return

--- a/secrets/localstore.go
+++ b/secrets/localstore.go
@@ -4,10 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/gob"
+	"fmt"
 	"os"
 	"sync"
-
-	"oss.nandlabs.io/golly/errutils"
 )
 
 const (
@@ -55,7 +54,7 @@ func (ls *localStore) Get(key string, ctx context.Context) (cred *Credential, er
 	if v, ok := ls.credentials[key]; ok {
 		cred = v
 	} else {
-		err = errutils.FmtError("Unable to find a credential with key %s", key)
+		err = fmt.Errorf("Unable to find a credential with key %s", key)
 	}
 
 	return

--- a/vfs/localfile.go
+++ b/vfs/localfile.go
@@ -1,13 +1,13 @@
 package vfs
 
 import (
+	"fmt"
 	"io/fs"
 	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
 
-	"oss.nandlabs.io/golly/errutils"
 	"oss.nandlabs.io/golly/fsutils"
 )
 
@@ -99,10 +99,10 @@ func (o *OsFile) Url() *url.URL {
 }
 
 func (o *OsFile) AddProperty(name string, value string) error {
-	return errutils.FmtError("Unsupported operation AddProperty for scheme")
+	return fmt.Errorf("Unsupported operation AddProperty for scheme")
 }
 
 func (o *OsFile) GetProperty(name string) (v string, err error) {
-	err = errutils.FmtError("Unsupported operation GetProperty for scheme")
+	err = fmt.Errorf("Unsupported operation GetProperty for scheme")
 	return
 }

--- a/vfs/vfs_manager.go
+++ b/vfs/vfs_manager.go
@@ -1,10 +1,9 @@
 package vfs
 
 import (
+	"fmt"
 	"net/url"
 	"sync"
-
-	"oss.nandlabs.io/golly/errutils"
 )
 
 var manager Manager
@@ -241,7 +240,7 @@ func (fs *fileSystems) getFsFor(src *url.URL) (vfs VFileSystem, err error) {
 	var ok bool
 	vfs, ok = fs.fileSystems[src.Scheme]
 	if !ok {
-		err = errutils.FmtError("Unsupported scheme %s for in the url %s", src.Scheme, src.String())
+		err = fmt.Errorf("Unsupported scheme %s for in the url %s", src.Scheme, src.String())
 	}
 	return
 }


### PR DESCRIPTION
Refactored to use fmt.Errorf instead of the deprecated errutils.FmtError func.

Also the errutils.FmtError func has been removed

Closes #23 