### PR TITLE
Updated Go Version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module oss.nandlabs.io/golly
 
-go 1.22
+go 1.22.1
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
Updated Go Version to use [1.N.P Syntax](https://go.dev/doc/toolchain#version)