### PR TITLE
Fix/codec

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"oss.nandlabs.io/golly/ioutils"
 )
 
 type Message struct {
@@ -26,7 +28,7 @@ type Message2 struct {
 
 func TestNewJson(t *testing.T) {
 	m := Message2{"TestUser", "Hello", 123124124}
-	c, _ := Get("application/json", nil)
+	c, _ := Get(ioutils.MimeApplicationJSON, nil)
 	buf := new(bytes.Buffer)
 	if err := c.Write(m, buf); err != nil {
 		t.Errorf("error in write: %d", err)
@@ -40,7 +42,7 @@ func TestNewJson(t *testing.T) {
 
 func TestNewDefaultJson(t *testing.T) {
 	m := Message2{"TestUser", "Hello", 123124124}
-	c, _ := GetDefault("application/json")
+	c, _ := GetDefault(ioutils.MimeApplicationJSON)
 	buf := new(bytes.Buffer)
 	if err := c.Write(m, buf); err != nil {
 		t.Errorf("error in write: %d", err)
@@ -54,7 +56,7 @@ func TestNewDefaultJson(t *testing.T) {
 
 func TestNewJsonCodec2(t *testing.T) {
 	var m Message
-	c, _ := Get("application/json", nil)
+	c, _ := Get(ioutils.MimeApplicationJSON, nil)
 	const input = `{"name":"Test","body":"Hello","time":123124124}`
 	b := strings.NewReader(input)
 	if err := c.Read(b, &m); err != nil {
@@ -72,7 +74,7 @@ func TestNewJsonCodec2(t *testing.T) {
 
 func TestNewXmlCodec(t *testing.T) {
 	m := XMLMessage{"Test", "Hello", 123124124}
-	c, _ := Get("text/xml", nil)
+	c := XmlCodec()
 	buf := new(bytes.Buffer)
 	if err := c.Write(m, buf); err != nil {
 		t.Errorf("error in write: %d", err)
@@ -85,7 +87,7 @@ func TestNewXmlCodec(t *testing.T) {
 
 func TestNewXmlCodec2(t *testing.T) {
 	var m XMLMessage
-	c, _ := Get("text/xml", nil)
+	c, _ := Get(ioutils.MimeTextXML, nil)
 	const input = `<XMLMessage><name>Test</name><body>Hello</body><time>123124124</time></XMLMessage>`
 	b := strings.NewReader(input)
 	if err := c.Read(b, &m); err != nil {

--- a/codec/json_codec.go
+++ b/codec/json_codec.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"oss.nandlabs.io/golly/codec/validator"
+	"oss.nandlabs.io/golly/ioutils"
 )
 
 const (
@@ -13,6 +14,7 @@ const (
 )
 
 var structValidator = validator.NewStructValidator()
+var jsonmimeTypes = []string{ioutils.MimeApplicationJSON}
 
 type jsonRW struct {
 	options map[string]interface{}
@@ -44,4 +46,9 @@ func (j *jsonRW) Write(v interface{}, w io.Writer) error {
 func (j *jsonRW) Read(r io.Reader, v interface{}) error {
 	decoder := json.NewDecoder(r)
 	return decoder.Decode(v)
+}
+
+// MimeTypes provides the list of mimetypes supported by the codec
+func (j *jsonRW) MimeTypes() []string {
+	return jsonmimeTypes
 }

--- a/codec/json_codec.go
+++ b/codec/json_codec.go
@@ -20,6 +20,16 @@ type jsonRW struct {
 	options map[string]interface{}
 }
 
+// Write encodes the given value v into JSON and writes it to the provided io.Writer w.
+// It supports options for escaping HTML and pretty-printing the JSON output.
+// The options are specified in the jsonRW struct's options map with the keys JsonEscapeHTML and PrettyPrint.
+//
+// Parameters:
+//   - v: The value to be encoded into JSON.
+//   - w: The io.Writer to write the JSON output to.
+//
+// Returns:
+//   - error: An error if the encoding or writing fails, otherwise nil.
 func (j *jsonRW) Write(v interface{}, w io.Writer) error {
 	//only utf-8 charset is supported
 	var escapeHtml = false
@@ -43,12 +53,24 @@ func (j *jsonRW) Write(v interface{}, w io.Writer) error {
 
 }
 
+// Read reads JSON-encoded data from the provided io.Reader and decodes it into the specified interface{}.
+// It returns an error if the decoding process fails.
+//
+// Parameters:
+//
+//	r - the io.Reader to read the JSON data from
+//	v - the interface{} to decode the JSON data into
+//
+// Returns:
+//
+//	error - an error if the decoding process fails, or nil if successful
 func (j *jsonRW) Read(r io.Reader, v interface{}) error {
 	decoder := json.NewDecoder(r)
 	return decoder.Decode(v)
 }
 
-// MimeTypes provides the list of mimetypes supported by the codec
+// MimeTypes returns a slice of strings representing the MIME types
+// that are supported by the jsonRW codec.
 func (j *jsonRW) MimeTypes() []string {
 	return jsonmimeTypes
 }

--- a/codec/xml_codec.go
+++ b/codec/xml_codec.go
@@ -3,6 +3,8 @@ package codec
 import (
 	"encoding/xml"
 	"io"
+
+	"oss.nandlabs.io/golly/ioutils"
 )
 
 const (
@@ -10,10 +12,21 @@ const (
 	xmlPrettyPrintIndent = "    "
 )
 
+var xmlmimeTypes = []string{ioutils.MimeApplicationXML, ioutils.MimeTextXML}
+
 type xmlRW struct {
 	options map[string]interface{}
 }
 
+// Write encodes the given value v into XML format and writes it to the provided io.Writer w.
+// If the PrettyPrint option is set to true in x.options, the output will be indented for readability.
+//
+// Parameters:
+//   - v: The value to be encoded into XML.
+//   - w: The io.Writer to which the encoded XML will be written.
+//
+// Returns:
+//   - error: An error if the encoding or writing process fails, otherwise nil.
 func (x *xmlRW) Write(v interface{}, w io.Writer) error {
 	encoder := xml.NewEncoder(w)
 	var prettyPrint = false
@@ -29,7 +42,21 @@ func (x *xmlRW) Write(v interface{}, w io.Writer) error {
 
 }
 
+// Read reads XML data from the provided io.Reader and decodes it into the provided interface{}.
+// It uses the xml.NewDecoder to decode the XML data.
+// Parameters:
+//   - r: An io.Reader from which the XML data will be read.
+//   - v: A pointer to the value where the decoded XML data will be stored.
+//
+// Returns:
+//   - An error if the decoding fails, otherwise nil.
 func (x *xmlRW) Read(r io.Reader, v interface{}) error {
 	decoder := xml.NewDecoder(r)
 	return decoder.Decode(v)
+}
+
+// MimeTypes returns a slice of strings representing the MIME types
+// that are supported by the xmlRW codec.
+func (x *xmlRW) MimeTypes() []string {
+	return xmlmimeTypes
 }

--- a/codec/yaml_codec.go
+++ b/codec/yaml_codec.go
@@ -4,18 +4,47 @@ import (
 	"io"
 
 	"gopkg.in/yaml.v3"
+	"oss.nandlabs.io/golly/ioutils"
 )
+
+var yamlmimeTypes = []string{ioutils.MimeTextYAML}
 
 type yamlRW struct {
 	options map[string]interface{}
 }
 
+// Write encodes the given value v into YAML format and writes it to the provided io.Writer w.
+// It returns an error if the encoding process fails.
+//
+// Parameters:
+//
+//	v - The value to be encoded into YAML format.
+//	w - The io.Writer where the encoded YAML data will be written.
+//
+// Returns:
+//
+//	error - An error if the encoding process fails, otherwise nil.
 func (y *yamlRW) Write(v interface{}, w io.Writer) error {
 	encoder := yaml.NewEncoder(w)
 	return encoder.Encode(v)
 }
 
+// Read reads YAML-encoded data from the provided io.Reader and decodes it into the provided interface{}.
+// It returns an error if the decoding process fails.
+//
+// Parameters:
+//   - r: An io.Reader from which the YAML data will be read.
+//   - v: A pointer to the value where the decoded data will be stored.
+//
+// Returns:
+//   - error: An error if the decoding process fails, otherwise nil.
 func (y *yamlRW) Read(r io.Reader, v interface{}) error {
 	decoder := yaml.NewDecoder(r)
 	return decoder.Decode(v)
+}
+
+// MimeTypes returns a slice of strings representing the MIME types
+// that are supported by the yamlRW codec.
+func (y *yamlRW) MimeTypes() []string {
+	return yamlmimeTypes
 }

--- a/messaging/base_message.go
+++ b/messaging/base_message.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"oss.nandlabs.io/golly/codec"
+	"oss.nandlabs.io/golly/ioutils"
 )
 
 type BaseMessage struct {
@@ -35,12 +36,12 @@ func (bm *BaseMessage) SetFrom(content io.Reader) (n int64, err error) {
 }
 
 func (bm *BaseMessage) WriteJSON(input interface{}) (err error) {
-	err = bm.WriteContent(input, codec.JSON)
+	err = bm.WriteContent(input, ioutils.MimeApplicationJSON)
 	return
 }
 
 func (bm *BaseMessage) WriteXML(input interface{}) (err error) {
-	err = bm.WriteContent(input, codec.XML)
+	err = bm.WriteContent(input, ioutils.MimeTextXML)
 	return
 }
 
@@ -67,12 +68,12 @@ func (bm *BaseMessage) ReadAsStr() string {
 }
 
 func (bm *BaseMessage) ReadJSON(out interface{}) (err error) {
-	err = bm.ReadContent(out, codec.JSON)
+	err = bm.ReadContent(out, ioutils.MimeApplicationJSON)
 	return
 }
 
 func (bm *BaseMessage) ReadXML(out interface{}) (err error) {
-	err = bm.ReadContent(out, codec.XML)
+	err = bm.ReadContent(out, ioutils.MimeTextXML)
 	return
 }
 

--- a/rest/server/context.go
+++ b/rest/server/context.go
@@ -6,10 +6,20 @@ import (
 	"strings"
 
 	"oss.nandlabs.io/golly/codec"
+	"oss.nandlabs.io/golly/ioutils"
 	"oss.nandlabs.io/golly/rest"
 	"oss.nandlabs.io/golly/textutils"
 	"oss.nandlabs.io/golly/turbo"
 )
+
+// jsonCodec is the default codec for json
+var jsonCodec = codec.JsonCodec()
+
+// xmlCodec is the default codec for xml
+var xmlCodec = codec.XmlCodec()
+
+// yamlCodec is the default codec for yaml
+var yamlCodec = codec.YamlCodec()
 
 // Context is the struct that holds the request and response of the server.
 type Context struct {
@@ -74,6 +84,24 @@ func (c *Context) Read(obj interface{}) error {
 	}
 	err = codec.Read(c.request.Body, obj)
 	return err
+}
+
+// WriteJSON writes the object to the response in JSON format.
+func (c *Context) WriteJSON(data interface{}) error {
+	c.SetHeader(rest.ContentTypeHeader, ioutils.MimeApplicationJSON)
+	return jsonCodec.Write(data, c.response)
+}
+
+// WriteXML writes the object to the response in XML format.
+func (c *Context) WriteXML(data interface{}) error {
+	c.SetHeader(rest.ContentTypeHeader, ioutils.MimeApplicationXML)
+	return xmlCodec.Write(data, c.response)
+}
+
+// WriteYAML writes the object to the response in YAML format.
+func (c *Context) WriteYAML(data interface{}) error {
+	c.SetHeader(rest.ContentTypeHeader, ioutils.MimeTextYAML)
+	return yamlCodec.Write(data, c.response)
 }
 
 // Write writes the object to the response with the given content type and status code.


### PR DESCRIPTION
1. Added helper methods for JSON, XML and YAML Codecs
2. Added support for new codecs to be registered. Mime types supported  out of box are not included in this registration as they are expected to be used extensively and we could avoid mutex locks for each get call.
3. Added support (rest methods) for  WriteJSON, WriteXML and WriteYaml in rest server context.