### PR TITLE
[#84] Added StopAll() invocation for sigterm and sigint os events.

### DIFF
--- a/managers/item_manager_test.go
+++ b/managers/item_manager_test.go
@@ -52,7 +52,7 @@ func TestItemManager_Items_AfterUnregister(t *testing.T) {
 	manager.Unregister("item2")
 
 	items := manager.Items()
-	expectedItems := []int{1, 3}
+	assert.ListHas(t, 1, items)
+	assert.ListHas(t, 3, items)
 
-	assert.ElementsMatch(t, items, expectedItems...)
 }


### PR DESCRIPTION
Added manager.StopAll() when OS SIGTEM or SIGINT events are captured by the process.
Closes #84 