### PR TITLE
docs: add released versions to cloud integrations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ go get oss.nandlabs.io/golly
 
 ### ☁️ Cloud Integrations
 
-| Repository                                      | Description                                                                              |
-| ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [golly-aws](https://github.com/nandlabs/golly-aws) | AWS service integrations: S3, SNS, SQS, Bedrock, and **Secrets Manager** for credentials |
-| [golly-gcp](https://github.com/nandlabs/golly-gcp) | GCP service integrations: Storage, Pub/Sub, GenAI, and **Secret Manager** for credentials |
-| [golly-vault](https://github.com/nandlabs/golly-vault) | HashiCorp Vault integration for centralized secret management with KV engines and advanced auth |
+| Repository                                      | Latest  | Description                                                                              |
+| ----------------------------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| [golly-aws](https://github.com/nandlabs/golly-aws) | v0.3.0 | AWS service integrations: S3, SNS, SQS, Bedrock, and **Secrets Manager** for credentials |
+| [golly-gcp](https://github.com/nandlabs/golly-gcp) | v0.2.0 | GCP service integrations: Storage, Pub/Sub, GenAI, and **Secret Manager** for credentials |
+| [golly-vault](https://github.com/nandlabs/golly-vault) | v0.1.0 | HashiCorp Vault integration for centralized secret management with KV engines and advanced auth |
 
 ### �🛠️ Infrastructure
 


### PR DESCRIPTION
## Description

Add a "Latest" version column to the Cloud Integrations table in the main README, reflecting the newly released versions of golly-aws (v0.3.0) and golly-gcp (v0.2.0).

### Related Issue

Follow-up to golly-aws PR #113 and golly-gcp PR #47 releases.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ✅ Test update (adding or modifying tests)
- [ ] 🔨 Build / CI changes

## Changes Made

- Added "Latest" column to the Cloud Integrations table in README.md
- golly-aws: v0.3.0 (AWS Secrets Manager store, SDK upgrades)
- golly-gcp: v0.2.0 (GCP Secret Manager store, dependency upgrades)
- golly-vault: v0.1.0

## Testing

- [ ] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

```
Documentation-only change — no test changes required.
```

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide

## Additional Context

This keeps the main golly README in sync with the latest cloud integration releases.