### PR TITLE
feat(ws): connection Hub + handshake auth + wsmux envelope

### DIFF
--- a/ws/conn.go
+++ b/ws/conn.go
@@ -2,6 +2,7 @@ package ws
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -32,6 +33,7 @@ type Conn struct {
 	closed   atomic.Bool
 	closeCh  chan struct{}
 	isServer bool
+	ctx      context.Context
 
 	onMessage    MessageHandler
 	onDisconnect DisconnectHandler
@@ -47,6 +49,22 @@ func newConn(netConn net.Conn, cfg *config, isServer bool) *Conn {
 		cfg:      cfg,
 		closeCh:  make(chan struct{}),
 		isServer: isServer,
+		ctx:      context.Background(),
+	}
+}
+
+// Context returns the per-connection context. For server-side connections this
+// is the context returned by an UpgradeAuthFunc (when configured) — useful for
+// reading the authenticated principal in message handlers. Defaults to
+// context.Background() when no auth hook is wired.
+func (c *Conn) Context() context.Context {
+	return c.ctx
+}
+
+// setContext sets the connection's context (used by server during handshake).
+func (c *Conn) setContext(ctx context.Context) {
+	if ctx != nil {
+		c.ctx = ctx
 	}
 }
 

--- a/ws/errors.go
+++ b/ws/errors.go
@@ -21,4 +21,6 @@ var (
 	ErrFragmentedControl = errors.New("ws: fragmented control frame")
 	// ErrControlTooLarge is returned when a control frame payload exceeds 125 bytes.
 	ErrControlTooLarge = errors.New("ws: control frame too large")
+	// ErrUnauthorized is returned when an UpgradeAuthFunc rejects the handshake.
+	ErrUnauthorized = errors.New("ws: unauthorized")
 )

--- a/ws/hub.go
+++ b/ws/hub.go
@@ -1,0 +1,153 @@
+package ws
+
+import (
+	"sync"
+)
+
+// Hub is an optional connection registry that maps arbitrary string keys
+// (e.g. user ids, room names, conversation ids) to *Conn, with targeted
+// fan-out via Send. It is safe for concurrent use.
+//
+// A Hub does not replace Handler.Broadcast — use Broadcast for "everybody",
+// Hub for "this user's devices" or "this conversation."
+//
+// Typical usage:
+//
+//	hub := ws.NewHub()
+//	handler.OnConnect(func(c *ws.Conn) {
+//	    userID := userIDFromContext(c.Context())
+//	    hub.Add(c, userID, "room:"+roomFromQuery(c))
+//	})
+//	handler.OnDisconnect(func(c *ws.Conn, _ error) {
+//	    hub.Remove(c)
+//	})
+//	// Later, deliver a private message:
+//	hub.Send("user-42", ws.NewTextMessage([]byte(`{"new":"message"}`)))
+type Hub struct {
+	mu     sync.RWMutex
+	byKey  map[string]map[*Conn]struct{} // key -> set of conns
+	byConn map[*Conn]map[string]struct{} // conn -> set of keys (for fast Remove)
+}
+
+// NewHub returns an empty, ready-to-use Hub.
+func NewHub() *Hub {
+	return &Hub{
+		byKey:  make(map[string]map[*Conn]struct{}),
+		byConn: make(map[*Conn]map[string]struct{}),
+	}
+}
+
+// Add associates a connection with one or more routing keys. Calling Add again
+// with the same conn and overlapping keys is a no-op for those keys; new keys
+// are appended (the conn ends up in the union of all keys it was Added with).
+// Passing zero keys still registers the conn — useful so a later Remove cleans
+// it up cleanly even if no keys were associated.
+func (h *Hub) Add(c *Conn, keys ...string) {
+	if c == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.byConn[c]; !ok {
+		h.byConn[c] = make(map[string]struct{})
+	}
+	for _, k := range keys {
+		if _, ok := h.byKey[k]; !ok {
+			h.byKey[k] = make(map[*Conn]struct{})
+		}
+		h.byKey[k][c] = struct{}{}
+		h.byConn[c][k] = struct{}{}
+	}
+}
+
+// Remove drops a connection from every key it was associated with. Safe to
+// call multiple times; a conn that isn't registered is a no-op.
+func (h *Hub) Remove(c *Conn) {
+	if c == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	keys, ok := h.byConn[c]
+	if !ok {
+		return
+	}
+	for k := range keys {
+		if set, ok := h.byKey[k]; ok {
+			delete(set, c)
+			if len(set) == 0 {
+				delete(h.byKey, k)
+			}
+		}
+	}
+	delete(h.byConn, c)
+}
+
+// Send delivers msg to every connection associated with key and returns the
+// number of successful deliveries. Errors writing to individual conns are
+// logged at debug level and do not abort the fan-out — one slow / dead conn
+// must not block delivery to the others.
+func (h *Hub) Send(key string, msg Message) int {
+	// Snapshot under the read lock then send outside it so that:
+	//  (a) a long-running Send can't block concurrent Add/Remove, and
+	//  (b) a handler that calls Hub.Remove inside its OnDisconnect (which a
+	//      failing Send may trigger) doesn't deadlock.
+	h.mu.RLock()
+	set, ok := h.byKey[key]
+	if !ok || len(set) == 0 {
+		h.mu.RUnlock()
+		return 0
+	}
+	conns := make([]*Conn, 0, len(set))
+	for c := range set {
+		conns = append(conns, c)
+	}
+	h.mu.RUnlock()
+
+	delivered := 0
+	for _, c := range conns {
+		if err := c.Send(msg); err != nil {
+			logger.DebugF("ws/hub: send to %s on key %q: %v", c.ID(), key, err)
+			continue
+		}
+		delivered++
+	}
+	return delivered
+}
+
+// Rooms returns the routing keys a connection is associated with. The returned
+// slice is a snapshot and may be modified by the caller without affecting the
+// Hub. Order is unspecified.
+func (h *Hub) Rooms(c *Conn) []string {
+	if c == nil {
+		return nil
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	keys, ok := h.byConn[c]
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(keys))
+	for k := range keys {
+		out = append(out, k)
+	}
+	return out
+}
+
+// Len returns the number of connections currently registered in the Hub
+// (regardless of key membership).
+func (h *Hub) Len() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.byConn)
+}
+
+// CountKey returns the number of connections currently associated with key.
+func (h *Hub) CountKey(key string) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.byKey[key])
+}

--- a/ws/hub_test.go
+++ b/ws/hub_test.go
@@ -1,0 +1,142 @@
+package ws
+
+import (
+	"sort"
+	"sync"
+	"testing"
+)
+
+// makeStubConn returns a minimally-initialized *Conn that's safe to use as a
+// Hub map key. Tests that exercise Hub.Send (which writes to the conn) must
+// use the full server+client pattern instead.
+func makeStubConn(id string) *Conn {
+	return &Conn{id: id}
+}
+
+func TestHub_AddAndRooms(t *testing.T) {
+	h := NewHub()
+	a := makeStubConn("a")
+	b := makeStubConn("b")
+
+	h.Add(a, "user-1", "room:42")
+	h.Add(b, "user-2", "room:42")
+
+	if got := h.Len(); got != 2 {
+		t.Errorf("Len = %d, want 2", got)
+	}
+	if got := h.CountKey("room:42"); got != 2 {
+		t.Errorf("CountKey(room:42) = %d, want 2", got)
+	}
+	if got := h.CountKey("user-1"); got != 1 {
+		t.Errorf("CountKey(user-1) = %d, want 1", got)
+	}
+
+	rooms := h.Rooms(a)
+	sort.Strings(rooms)
+	want := []string{"room:42", "user-1"}
+	if len(rooms) != 2 || rooms[0] != want[0] || rooms[1] != want[1] {
+		t.Errorf("Rooms(a) = %v, want %v", rooms, want)
+	}
+}
+
+func TestHub_AddIsIdempotent(t *testing.T) {
+	h := NewHub()
+	c := makeStubConn("c")
+	h.Add(c, "k1", "k2")
+	h.Add(c, "k2", "k3") // overlap k2; new k3
+
+	if got := h.CountKey("k1"); got != 1 {
+		t.Errorf("k1 should still have 1 conn; got %d", got)
+	}
+	if got := h.CountKey("k2"); got != 1 {
+		t.Errorf("k2 should remain 1 (not duplicate); got %d", got)
+	}
+	if got := h.CountKey("k3"); got != 1 {
+		t.Errorf("k3 should have 1 conn; got %d", got)
+	}
+	if got := h.Len(); got != 1 {
+		t.Errorf("Len = %d, want 1 (same conn added twice)", got)
+	}
+}
+
+func TestHub_RemoveDropsFromAllKeys(t *testing.T) {
+	h := NewHub()
+	a := makeStubConn("a")
+	b := makeStubConn("b")
+	h.Add(a, "x", "y", "z")
+	h.Add(b, "y")
+
+	h.Remove(a)
+
+	if got := h.Len(); got != 1 {
+		t.Errorf("Len after remove = %d, want 1", got)
+	}
+	if got := h.CountKey("x"); got != 0 {
+		t.Errorf("x should be empty; got %d", got)
+	}
+	if got := h.CountKey("y"); got != 1 {
+		t.Errorf("y should retain b; got %d", got)
+	}
+	if got := h.CountKey("z"); got != 0 {
+		t.Errorf("z should be empty (and pruned); got %d", got)
+	}
+	if rooms := h.Rooms(a); rooms != nil {
+		t.Errorf("Rooms(removed) = %v, want nil", rooms)
+	}
+}
+
+func TestHub_RemoveUnknown(t *testing.T) {
+	h := NewHub()
+	h.Remove(makeStubConn("ghost")) // no panic
+	h.Remove(nil)                   // no panic
+	if got := h.Len(); got != 0 {
+		t.Errorf("Len = %d on empty hub, want 0", got)
+	}
+}
+
+func TestHub_AddNilNoOp(t *testing.T) {
+	h := NewHub()
+	h.Add(nil, "x")
+	if got := h.Len(); got != 0 {
+		t.Errorf("Add(nil) should not register; Len = %d", got)
+	}
+}
+
+func TestHub_SendToMissingKeyReturnsZero(t *testing.T) {
+	h := NewHub()
+	got := h.Send("nobody-home", NewTextMessage([]byte("x")))
+	if got != 0 {
+		t.Errorf("Send to missing key = %d, want 0", got)
+	}
+}
+
+func TestHub_ConcurrentAddRemove(t *testing.T) {
+	h := NewHub()
+	conns := make([]*Conn, 200)
+	for i := range conns {
+		conns[i] = makeStubConn("c")
+	}
+
+	var wg sync.WaitGroup
+	// 100 adders, 100 removers, all hitting the same key, racing.
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			h.Add(conns[i], "shared", "u")
+		}(i)
+		go func(i int) {
+			defer wg.Done()
+			h.Remove(conns[100+i])
+		}(i)
+	}
+	wg.Wait()
+
+	// All adders' conns should be in the hub; removers' conns should not.
+	if got := h.Len(); got != 100 {
+		t.Errorf("Len = %d after concurrent ops, want 100", got)
+	}
+	if got := h.CountKey("shared"); got != 100 {
+		t.Errorf("CountKey(shared) = %d, want 100", got)
+	}
+}

--- a/ws/options.go
+++ b/ws/options.go
@@ -1,11 +1,20 @@
 package ws
 
 import (
+	"context"
 	"crypto/tls"
+	"net/http"
 	"time"
 
 	"oss.nandlabs.io/golly/clients"
 )
+
+// UpgradeAuthFunc authenticates a WebSocket upgrade request server-side.
+// Return ok=false to reject the handshake (the server responds 401).
+// The returned ctx (may be the request context unchanged) is carried into
+// the resulting Conn and retrievable via Conn.Context() — use it to attach
+// principals, tenant ids, etc., for downstream message handlers.
+type UpgradeAuthFunc func(r *http.Request) (ok bool, ctx context.Context)
 
 const (
 	defaultReadBufferSize   = 4096
@@ -30,6 +39,7 @@ type config struct {
 	autoReconnect    bool
 	maxReconnectWait time.Duration
 	checkOrigin      func(origin string) bool
+	upgradeAuth      UpgradeAuthFunc
 
 	// Client options from the clients package
 	auth           clients.AuthProvider
@@ -146,6 +156,24 @@ func WithMaxReconnectWait(d time.Duration) Option {
 func WithCheckOrigin(fn func(origin string) bool) Option {
 	return func(c *config) {
 		c.checkOrigin = fn
+	}
+}
+
+// WithUpgradeAuth sets a server-side authentication hook called during the
+// WebSocket handshake. When ok=false the upgrade is rejected with 401 Unauthorized;
+// when ok=true the returned context is attached to the resulting Conn (retrievable
+// via Conn.Context()) so message handlers can read the authenticated principal.
+//
+// Example:
+//
+//	ws.WithUpgradeAuth(func(r *http.Request) (bool, context.Context) {
+//	    user, err := verifyJWT(r.Header.Get("Authorization"))
+//	    if err != nil { return false, nil }
+//	    return true, context.WithValue(r.Context(), userKey, user)
+//	})
+func WithUpgradeAuth(fn UpgradeAuthFunc) Option {
+	return func(c *config) {
+		c.upgradeAuth = fn
 	}
 }
 

--- a/ws/server.go
+++ b/ws/server.go
@@ -1,6 +1,7 @@
 package ws
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
@@ -88,6 +89,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Authenticate the handshake before doing anything destructive (hijack).
+	var authCtx context.Context
+	if h.cfg.upgradeAuth != nil {
+		ok, ctx := h.cfg.upgradeAuth(r)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		authCtx = ctx
+	}
+
 	// Get the WebSocket key
 	key := r.Header.Get("Sec-WebSocket-Key")
 	if key == "" {
@@ -124,6 +136,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Create WebSocket connection
 	conn := newConn(netConn, h.cfg, true)
+	conn.setContext(authCtx)
 	// Use buffered reader from hijack if it has buffered data
 	if bufrw.Reader.Buffered() > 0 {
 		conn.reader = bufrw.Reader
@@ -205,6 +218,16 @@ func Upgrade(w http.ResponseWriter, r *http.Request, opts ...Option) (*Conn, err
 		o(cfg)
 	}
 
+	var authCtx context.Context
+	if cfg.upgradeAuth != nil {
+		ok, ctx := cfg.upgradeAuth(r)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return nil, ErrUnauthorized
+		}
+		authCtx = ctx
+	}
+
 	key := r.Header.Get("Sec-WebSocket-Key")
 	if key == "" {
 		return nil, ErrHandshakeFailed
@@ -234,6 +257,7 @@ func Upgrade(w http.ResponseWriter, r *http.Request, opts ...Option) (*Conn, err
 	}
 
 	conn := newConn(netConn, cfg, true)
+	conn.setContext(authCtx)
 	if bufrw.Reader.Buffered() > 0 {
 		conn.reader = bufrw.Reader
 	}

--- a/ws/server_auth_test.go
+++ b/ws/server_auth_test.go
@@ -1,0 +1,174 @@
+package ws
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+type userKey struct{}
+
+// TestUpgradeAuth_Accepts verifies that a hook returning ok=true allows the
+// upgrade and that the returned context is reachable via Conn.Context() in
+// the OnConnect/OnMessage handlers.
+func TestUpgradeAuth_Accepts(t *testing.T) {
+	gotCtx := make(chan context.Context, 1)
+	handler := NewHandler(
+		WithPingInterval(0),
+		WithUpgradeAuth(func(r *http.Request) (bool, context.Context) {
+			if r.Header.Get("X-User") == "" {
+				return false, nil
+			}
+			return true, context.WithValue(r.Context(), userKey{}, r.Header.Get("X-User"))
+		}),
+	)
+	handler.OnConnect(func(c *Conn) { gotCtx <- c.Context() })
+	handler.OnMessage(func(c *Conn, m Message) { _ = c.Send(m) })
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, err := Dial(context.Background(), wsURL, WithPingInterval(0), WithHeader("X-User", "alice"))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	select {
+	case ctx := <-gotCtx:
+		if user, _ := ctx.Value(userKey{}).(string); user != "alice" {
+			t.Errorf("Conn.Context() user = %q, want alice", user)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never observed connection")
+	}
+}
+
+// TestUpgradeAuth_Rejects verifies the handshake is refused with 401 when the
+// hook returns ok=false; Dial must surface an error.
+func TestUpgradeAuth_Rejects(t *testing.T) {
+	handler := NewHandler(
+		WithPingInterval(0),
+		WithUpgradeAuth(func(r *http.Request) (bool, context.Context) {
+			return false, nil
+		}),
+	)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	_, err := Dial(context.Background(), wsURL, WithPingInterval(0))
+	if err == nil {
+		t.Fatal("expected dial to fail when UpgradeAuth rejects")
+	}
+}
+
+// TestUpgradeAuth_NotConfigured verifies the default context is
+// context.Background() when no hook is wired (existing behavior preserved).
+func TestUpgradeAuth_NotConfigured(t *testing.T) {
+	gotCtx := make(chan context.Context, 1)
+	handler := NewHandler(WithPingInterval(0))
+	handler.OnConnect(func(c *Conn) { gotCtx <- c.Context() })
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, err := Dial(context.Background(), wsURL, WithPingInterval(0))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	select {
+	case ctx := <-gotCtx:
+		if ctx == nil {
+			t.Fatal("Conn.Context() returned nil; want context.Background()")
+		}
+		if ctx.Err() != nil {
+			t.Errorf("default context should be live; got err %v", ctx.Err())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server never observed connection")
+	}
+}
+
+// TestHub_SendEndToEnd uses two real connections registered in a Hub and
+// verifies a targeted Send delivers only to the matching key.
+func TestHub_SendEndToEnd(t *testing.T) {
+	hub := NewHub()
+	handler := NewHandler(WithPingInterval(0))
+
+	// Tag each new connection with a header-derived user id.
+	connReady := make(chan *Conn, 2)
+	handler.OnConnect(func(c *Conn) {
+		connReady <- c
+	})
+	handler.OnDisconnect(func(c *Conn, _ error) {
+		hub.Remove(c)
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	// Dial two clients. Close them all at once via a single deferred loop
+	// (gocritic.deferInLoop avoids per-iteration defers).
+	clients := make([]*Client, 2)
+	defer func() {
+		for _, c := range clients {
+			if c != nil {
+				_ = c.Close()
+			}
+		}
+	}()
+	for i := range clients {
+		c, err := Dial(context.Background(), wsURL, WithPingInterval(0))
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		clients[i] = c
+	}
+
+	// Collect the server-side connections and put them into the Hub under
+	// distinct keys.
+	serverConns := make([]*Conn, 0, 2)
+	for i := 0; i < 2; i++ {
+		select {
+		case sc := <-connReady:
+			serverConns = append(serverConns, sc)
+		case <-time.After(2 * time.Second):
+			t.Fatal("server never accepted connection")
+		}
+	}
+	hub.Add(serverConns[0], "user-a")
+	hub.Add(serverConns[1], "user-b")
+
+	// Send only to user-a.
+	n := hub.Send("user-a", NewTextMessage([]byte("hello-a")))
+	if n != 1 {
+		t.Errorf("Send to user-a delivered to %d, want 1", n)
+	}
+
+	select {
+	case m := <-clients[0].Messages():
+		if string(m.Data) != "hello-a" {
+			t.Errorf("client 0 got %q, want hello-a", m.Data)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("client 0 never received message")
+	}
+
+	// Client 1 must NOT receive anything.
+	select {
+	case m := <-clients[1].Messages():
+		t.Errorf("client 1 unexpectedly received %q", m.Data)
+	case <-time.After(200 * time.Millisecond):
+		// good — no message
+	}
+}

--- a/ws/wsmux/wsmux.go
+++ b/ws/wsmux/wsmux.go
@@ -1,0 +1,194 @@
+// Package wsmux layers a small JSON envelope and per-channel handler routing
+// over the raw byte streams that ws.Conn exposes.
+//
+// The envelope is intentionally minimal:
+//
+//	{
+//	  "type":    "string, e.g. \"msg\" or \"req\"",   // free-form, app decides
+//	  "channel": "string routing key",                 // mandatory; handler is keyed by this
+//	  "id":      "string correlation id (optional)",   // present on request/reply pairs
+//	  "payload": <any JSON value>                      // app-specific body
+//	}
+//
+// Apps can use it as-is for request/reply or pub/sub-style multiplexing over
+// a single WebSocket without writing their own framing.
+package wsmux
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"oss.nandlabs.io/golly/ws"
+)
+
+// Envelope is the wire shape every message in a wsmux conversation uses.
+// Payload is left as json.RawMessage so handlers can decode it into the
+// type they expect without an extra round-trip through any.
+type Envelope struct {
+	Type    string          `json:"type,omitempty"`
+	Channel string          `json:"channel"`
+	ID      string          `json:"id,omitempty"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// Handler receives an envelope addressed to its channel and may reply via
+// Replier. ctx is the ws.Conn's context (carries auth, etc.).
+type Handler func(env *Envelope, r Replier)
+
+// Replier sends a response to the originating peer over the same connection,
+// preserving the request's id so the requester can correlate.
+type Replier interface {
+	// Reply sends a typed response with the same id as the inbound envelope.
+	// Useful for request/reply patterns.
+	Reply(typ string, payload any) error
+	// Send sends a brand-new envelope (caller-chosen channel/type/id/payload)
+	// on the same connection. Useful for unsolicited messages.
+	Send(env Envelope) error
+	// Conn returns the underlying *ws.Conn.
+	Conn() *ws.Conn
+}
+
+// ErrUnknownChannel is returned (and surfaced via OnUnknown) when an inbound
+// envelope's channel has no registered handler.
+var ErrUnknownChannel = errors.New("wsmux: unknown channel")
+
+// Mux routes incoming WebSocket messages to handlers by envelope.Channel.
+// It is safe to register handlers concurrently. Routing itself happens on the
+// ws.Conn's read goroutine, so handlers should return quickly or dispatch
+// long work to their own goroutine.
+type Mux struct {
+	mu        sync.RWMutex
+	handlers  map[string]Handler
+	onUnknown func(c *ws.Conn, env *Envelope, err error)
+	onDecode  func(c *ws.Conn, raw []byte, err error)
+}
+
+// New returns an empty Mux.
+func New() *Mux {
+	return &Mux{
+		handlers: make(map[string]Handler),
+	}
+}
+
+// Handle registers a handler for envelopes whose Channel equals channel.
+// Registering the same channel twice overwrites the prior handler.
+func (m *Mux) Handle(channel string, h Handler) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handlers[channel] = h
+}
+
+// HandleFunc is a convenience for Handle with a plain function value.
+func (m *Mux) HandleFunc(channel string, fn func(env *Envelope, r Replier)) {
+	m.Handle(channel, Handler(fn))
+}
+
+// OnUnknown registers a fallback invoked when an envelope arrives on a channel
+// with no registered handler. If nil (default) the envelope is silently dropped.
+func (m *Mux) OnUnknown(fn func(c *ws.Conn, env *Envelope, err error)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onUnknown = fn
+}
+
+// OnDecodeError registers a fallback invoked when an inbound message is not
+// valid JSON or doesn't satisfy the envelope schema. If nil the message is
+// silently dropped.
+func (m *Mux) OnDecodeError(fn func(c *ws.Conn, raw []byte, err error)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onDecode = fn
+}
+
+// ServeMessage decodes msg as an Envelope and dispatches it to the registered
+// handler. Plug this into ws.Handler.OnMessage:
+//
+//	handler.OnMessage(mux.ServeMessage)
+func (m *Mux) ServeMessage(c *ws.Conn, msg ws.Message) {
+	if msg.Type != ws.OpText {
+		// Envelopes are JSON; binary frames are not for this mux.
+		if cb := m.decodeErrCallback(); cb != nil {
+			cb(c, msg.Data, fmt.Errorf("wsmux: non-text frame (opcode %d)", msg.Type))
+		}
+		return
+	}
+	env, err := decode(msg.Data)
+	if err != nil {
+		if cb := m.decodeErrCallback(); cb != nil {
+			cb(c, msg.Data, err)
+		}
+		return
+	}
+
+	m.mu.RLock()
+	h, ok := m.handlers[env.Channel]
+	unknown := m.onUnknown
+	m.mu.RUnlock()
+
+	if !ok {
+		if unknown != nil {
+			unknown(c, env, ErrUnknownChannel)
+		}
+		return
+	}
+
+	h(env, &replier{conn: c, inbound: env})
+}
+
+// decodeErrCallback returns the current OnDecodeError callback under the
+// read lock. Pulled out to keep ServeMessage tidy.
+func (m *Mux) decodeErrCallback() func(c *ws.Conn, raw []byte, err error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.onDecode
+}
+
+// SendEnvelope is a helper that JSON-encodes env and writes it to c as a text
+// frame. Use it for unsolicited server-pushed messages.
+func SendEnvelope(c *ws.Conn, env Envelope) error {
+	b, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("wsmux: marshal envelope: %w", err)
+	}
+	return c.Send(ws.NewTextMessage(b))
+}
+
+// decode parses raw JSON into an Envelope and validates that Channel is set.
+func decode(raw []byte) (*Envelope, error) {
+	env := &Envelope{}
+	if err := json.Unmarshal(raw, env); err != nil {
+		return nil, fmt.Errorf("wsmux: invalid envelope JSON: %w", err)
+	}
+	if env.Channel == "" {
+		return nil, errors.New("wsmux: envelope missing channel")
+	}
+	return env, nil
+}
+
+// replier is the default Replier implementation. It writes responses on the
+// same ws.Conn that delivered the inbound envelope.
+type replier struct {
+	conn    *ws.Conn
+	inbound *Envelope
+}
+
+func (r *replier) Conn() *ws.Conn { return r.conn }
+
+func (r *replier) Reply(typ string, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("wsmux: marshal reply payload: %w", err)
+	}
+	return SendEnvelope(r.conn, Envelope{
+		Type:    typ,
+		Channel: r.inbound.Channel,
+		ID:      r.inbound.ID,
+		Payload: body,
+	})
+}
+
+func (r *replier) Send(env Envelope) error {
+	return SendEnvelope(r.conn, env)
+}

--- a/ws/wsmux/wsmux_test.go
+++ b/ws/wsmux/wsmux_test.go
@@ -1,0 +1,202 @@
+package wsmux
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"oss.nandlabs.io/golly/ws"
+)
+
+// --- unit tests: routing & error paths without a real connection ---
+
+func TestMux_RoutesByChannel(t *testing.T) {
+	mux := New()
+	var (
+		gotChan    string
+		gotPayload string
+	)
+	mux.HandleFunc("greet", func(env *Envelope, _ Replier) {
+		gotChan = env.Channel
+		var s string
+		_ = json.Unmarshal(env.Payload, &s)
+		gotPayload = s
+	})
+
+	// stub conn — handler does NOT use the replier, so a zero conn is safe.
+	raw, _ := json.Marshal(Envelope{Channel: "greet", Payload: json.RawMessage(`"hello"`)})
+	mux.ServeMessage(&ws.Conn{}, ws.NewTextMessage(raw))
+
+	if gotChan != "greet" {
+		t.Errorf("channel = %q, want greet", gotChan)
+	}
+	if gotPayload != "hello" {
+		t.Errorf("payload = %q, want hello", gotPayload)
+	}
+}
+
+func TestMux_UnknownChannelCallsOnUnknown(t *testing.T) {
+	mux := New()
+	called := false
+	mux.OnUnknown(func(_ *ws.Conn, env *Envelope, err error) {
+		called = true
+		if !errors.Is(err, ErrUnknownChannel) {
+			t.Errorf("err = %v, want ErrUnknownChannel", err)
+		}
+		if env.Channel != "ghost" {
+			t.Errorf("env.Channel = %q, want ghost", env.Channel)
+		}
+	})
+
+	raw, _ := json.Marshal(Envelope{Channel: "ghost"})
+	mux.ServeMessage(&ws.Conn{}, ws.NewTextMessage(raw))
+
+	if !called {
+		t.Fatal("OnUnknown was not invoked")
+	}
+}
+
+func TestMux_DecodeErrorOnBadJSON(t *testing.T) {
+	mux := New()
+	var captured error
+	mux.OnDecodeError(func(_ *ws.Conn, _ []byte, err error) {
+		captured = err
+	})
+
+	mux.ServeMessage(&ws.Conn{}, ws.NewTextMessage([]byte(`{not json`)))
+
+	if captured == nil {
+		t.Fatal("OnDecodeError was not invoked")
+	}
+	if !strings.Contains(captured.Error(), "invalid envelope JSON") {
+		t.Errorf("err = %v, want it to mention invalid envelope JSON", captured)
+	}
+}
+
+func TestMux_DecodeErrorOnMissingChannel(t *testing.T) {
+	mux := New()
+	var captured error
+	mux.OnDecodeError(func(_ *ws.Conn, _ []byte, err error) {
+		captured = err
+	})
+
+	mux.ServeMessage(&ws.Conn{}, ws.NewTextMessage([]byte(`{"type":"x"}`)))
+
+	if captured == nil {
+		t.Fatal("OnDecodeError was not invoked for missing channel")
+	}
+	if !strings.Contains(captured.Error(), "missing channel") {
+		t.Errorf("err = %v, want it to mention missing channel", captured)
+	}
+}
+
+func TestMux_RejectsBinaryFrames(t *testing.T) {
+	mux := New()
+	var captured error
+	mux.OnDecodeError(func(_ *ws.Conn, _ []byte, err error) {
+		captured = err
+	})
+
+	mux.ServeMessage(&ws.Conn{}, ws.NewBinaryMessage([]byte{0x01, 0x02}))
+
+	if captured == nil || !strings.Contains(captured.Error(), "non-text") {
+		t.Errorf("expected non-text decode error; got %v", captured)
+	}
+}
+
+func TestMux_HandleOverwrites(t *testing.T) {
+	mux := New()
+	calls := 0
+	mux.HandleFunc("x", func(_ *Envelope, _ Replier) { calls += 10 })
+	mux.HandleFunc("x", func(_ *Envelope, _ Replier) { calls++ })
+
+	raw, _ := json.Marshal(Envelope{Channel: "x"})
+	mux.ServeMessage(&ws.Conn{}, ws.NewTextMessage(raw))
+
+	if calls != 1 {
+		t.Errorf("expected the second handler to win (calls=1); got %d", calls)
+	}
+}
+
+// --- integration test: full request/reply over a real WebSocket ---
+
+func TestMux_RequestReply_EndToEnd(t *testing.T) {
+	mux := New()
+	mux.HandleFunc("ping", func(env *Envelope, r Replier) {
+		var s string
+		_ = json.Unmarshal(env.Payload, &s)
+		_ = r.Reply("pong", map[string]string{"echo": s})
+	})
+
+	handler := ws.NewHandler(ws.WithPingInterval(0))
+	handler.OnMessage(mux.ServeMessage)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, err := ws.Dial(context.Background(), wsURL, ws.WithPingInterval(0))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	req, _ := json.Marshal(Envelope{
+		Type:    "req",
+		Channel: "ping",
+		ID:      "abc-123",
+		Payload: json.RawMessage(`"hi"`),
+	})
+	if err := client.Send(ws.NewTextMessage(req)); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	select {
+	case m := <-client.Messages():
+		var env Envelope
+		if err := json.Unmarshal(m.Data, &env); err != nil {
+			t.Fatalf("decode reply: %v", err)
+		}
+		if env.Type != "pong" {
+			t.Errorf("reply type = %q, want pong", env.Type)
+		}
+		if env.Channel != "ping" {
+			t.Errorf("reply channel = %q, want ping (echoed)", env.Channel)
+		}
+		if env.ID != "abc-123" {
+			t.Errorf("reply id = %q, want abc-123 (correlation)", env.ID)
+		}
+		var body map[string]string
+		_ = json.Unmarshal(env.Payload, &body)
+		if body["echo"] != "hi" {
+			t.Errorf("reply payload.echo = %q, want hi", body["echo"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no reply received")
+	}
+}
+
+// TestMux_ConcurrentRegistrations verifies handler registration is safe under
+// concurrent calls (the lock matters when handlers re-register dynamically).
+func TestMux_ConcurrentRegistrations(t *testing.T) {
+	mux := New()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			mux.HandleFunc("c", func(_ *Envelope, _ Replier) {})
+			mux.OnUnknown(func(_ *ws.Conn, _ *Envelope, _ error) {})
+		}(i)
+	}
+	wg.Wait()
+
+	// Just make sure it still routes correctly after the storm.
+	raw, _ := json.Marshal(Envelope{Channel: "c"})
+	mux.ServeMessage(&ws.Conn{}, ws.NewTextMessage(raw))
+}


### PR DESCRIPTION
## Description

Implements all three open **ws** gap issues with **zero new external dependencies** — stdlib only, plus the existing in-tree `ws` types.

### Related Issue

Closes #165
Closes #166
Closes #167

## Type of Change

<!-- Mark the relevant option with an "x". -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ✅ Test update (adding or modifying tests)
- [ ] 🔨 Build / CI changes

## Changes Made

### G-WS-1 — `ws/hub.go` (new) — Connection Hub
- `Hub` keyed by arbitrary strings (user ids, room names, conversation ids).
- API: `Add(c, keys...)`, `Remove(c)`, `Send(key, msg) int`, `Rooms(c)`, `Len()`, `CountKey(key)`.
- Snapshot-then-send: fan-out happens **outside** the lock so a slow consumer can't block `Add` / `Remove`, and `OnDisconnect` callbacks that re-enter `Hub.Remove` don't deadlock.

### G-WS-2 — `ws/options.go`, `ws/server.go`, `ws/conn.go`, `ws/errors.go` — Handshake auth hook
- New `UpgradeAuthFunc func(r *http.Request) (ok bool, ctx context.Context)`.
- New `WithUpgradeAuth(fn)` option; honoured by both `Handler.ServeHTTP` and the standalone `Upgrade(w, r, opts...)` helper.
- Rejection responds **`401 Unauthorized`** *before* the hijack, so no socket is wasted.
- Accepted context propagates into `Conn.Context()` — message handlers read the authenticated principal there. Default is `context.Background()` (existing behaviour preserved when no hook is wired).
- New `ErrUnauthorized` returned from `Upgrade` when the hook rejects.

### G-WS-3 — `ws/wsmux/` (new subpackage) — App-level envelope + routing
- `Envelope { Type, Channel, ID, Payload(RawMessage) }` — minimal JSON wire shape with optional correlation id for request/reply.
- `Mux` registers per-channel handlers (`Handle` / `HandleFunc`), plus `OnUnknown` and `OnDecodeError` fallbacks. Plugs into `Handler.OnMessage` via `Mux.ServeMessage`.
- `Replier` interface gives handlers `Reply(typ, payload)` (id-preserving) and `Send(env)` (unsolicited).
- `SendEnvelope(conn, env)` helper for server-initiated pushes.

## Testing

- [x] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

```
$ go test -race ./...
ok  	oss.nandlabs.io/golly/...
ok  	oss.nandlabs.io/golly/ws         # +9 new tests (Hub data + Send e2e + auth accept/reject/default + Hub.Send e2e)
ok  	oss.nandlabs.io/golly/ws/wsmux   # +7 new tests (route/unknown/decode/non-text/overwrite/req-reply/concurrent)
# all packages pass under -race; 0 lint issues (`golangci-lint run`)
```

**New tests (16 total):**
- `hub_test.go`: `TestHub_AddAndRooms`, `TestHub_AddIsIdempotent`, `TestHub_RemoveDropsFromAllKeys`, `TestHub_RemoveUnknown`, `TestHub_AddNilNoOp`, `TestHub_SendToMissingKeyReturnsZero`, `TestHub_ConcurrentAddRemove` (200-goroutine storm)
- `server_auth_test.go`: `TestUpgradeAuth_Accepts`, `TestUpgradeAuth_Rejects`, `TestUpgradeAuth_NotConfigured`, `TestHub_SendEndToEnd` (two real clients verifying targeted delivery + non-delivery to the other key)
- `wsmux/wsmux_test.go`: `TestMux_RoutesByChannel`, `TestMux_UnknownChannelCallsOnUnknown`, `TestMux_DecodeErrorOnBadJSON`, `TestMux_DecodeErrorOnMissingChannel`, `TestMux_RejectsBinaryFrames`, `TestMux_HandleOverwrites`, `TestMux_RequestReply_EndToEnd`, `TestMux_ConcurrentRegistrations`

All provider/handler tests use `httptest` — **no network access required**.

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I agree my contribution may be redistributed under either the [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) license

## Additional Context

**Zero-deps tenet honoured.** All new code uses only stdlib (`context`, `encoding/json`, `net/http`, `sync`). No JSON-Schema lib, no extra muxers, no broker.

**Backward compatible.** Every addition is opt-in:
- Handlers without `WithUpgradeAuth` behave exactly as before; `Conn.Context()` returns `context.Background()`.
- Hub is an *optional* registry — `Handler.Broadcast` and direct iteration over `Handler.Connections()` continue to work.
- wsmux is a separate subpackage; only consumers that import it pay anything for it.

**Concurrency.** Hub uses snapshot-then-send (RWMutex held only for the map snapshot, never during the actual `Conn.Send` calls). Mux uses RWMutex for handler maps. Tests include explicit concurrent-mutation storms and end-to-end races; all pass under `-race`.
