### PR TITLE
feat(lifecycle): health/readiness probes + HTTP handler

### DIFF
--- a/lifecycle/health.go
+++ b/lifecycle/health.go
@@ -1,0 +1,143 @@
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// HealthStatus represents one Component's health verdict at a point in time.
+// OK=true means healthy; Message and Details are free-form diagnostics.
+type HealthStatus struct {
+	OK      bool           `json:"ok"`
+	Message string         `json:"message,omitempty"`
+	Details map[string]any `json:"details,omitempty"`
+	// Latency records how long the underlying Check call took (set by the
+	// aggregator, not the checker).
+	Latency time.Duration `json:"latency,omitempty"`
+}
+
+// HealthChecker is the optional interface a Component may implement to
+// participate in active health probing. Components that do NOT implement
+// HealthChecker are reported by Health() based on their ComponentState only.
+type HealthChecker interface {
+	// Check returns the current health of this component. Implementations
+	// should respect ctx for cancellation/deadline and return quickly.
+	Check(ctx context.Context) HealthStatus
+}
+
+// HealthReport is the aggregated map returned by Health(): one entry per
+// registered component, keyed by component Id.
+type HealthReport map[string]HealthStatus
+
+// AllOK returns true iff every entry in the report is OK.
+func (r HealthReport) AllOK() bool {
+	for _, s := range r {
+		if !s.OK {
+			return false
+		}
+	}
+	return true
+}
+
+// Health aggregates the health of every registered component on the manager.
+// Components that implement HealthChecker have Check() invoked in parallel
+// (each respecting ctx). Components that do not are mapped from
+// ComponentState: Running → OK; Starting/Stopping → not OK with the state in
+// the message; Error → not OK; everything else → not OK.
+//
+// The implementation lives on *SimpleComponentManager so it is opt-in via
+// type assertion at call sites:
+//
+//	if mgr, ok := componentManager.(*lifecycle.SimpleComponentManager); ok {
+//	    report := mgr.Health(ctx)
+//	}
+func (scm *SimpleComponentManager) Health(ctx context.Context) HealthReport {
+	// Snapshot under the read lock then run probes outside it so a slow
+	// HealthChecker can't block Register/Unregister/StartAll.
+	scm.cMutex.RLock()
+	snap := make([]Component, 0, len(scm.components))
+	for _, c := range scm.components {
+		snap = append(snap, c)
+	}
+	scm.cMutex.RUnlock()
+
+	if len(snap) == 0 {
+		return HealthReport{}
+	}
+
+	report := make(HealthReport, len(snap))
+	type result struct {
+		id     string
+		status HealthStatus
+	}
+	resCh := make(chan result, len(snap))
+
+	var wg sync.WaitGroup
+	for _, c := range snap {
+		wg.Add(1)
+		go func(c Component) {
+			defer wg.Done()
+			resCh <- result{id: c.Id(), status: checkComponent(ctx, c)}
+		}(c)
+	}
+	wg.Wait()
+	close(resCh)
+	for r := range resCh {
+		report[r.id] = r.status
+	}
+	return report
+}
+
+// checkComponent invokes the HealthChecker if implemented, otherwise derives
+// a HealthStatus from ComponentState. Records latency for the Check call.
+func checkComponent(ctx context.Context, c Component) HealthStatus {
+	if hc, ok := c.(HealthChecker); ok {
+		start := time.Now()
+		s := hc.Check(ctx)
+		s.Latency = time.Since(start)
+		return s
+	}
+	return stateToHealth(c.State())
+}
+
+// stateToHealth maps a coarse ComponentState into a HealthStatus.
+func stateToHealth(state ComponentState) HealthStatus {
+	switch state {
+	case Running:
+		return HealthStatus{OK: true}
+	case Starting:
+		return HealthStatus{OK: false, Message: "starting"}
+	case Stopping:
+		return HealthStatus{OK: false, Message: "stopping"}
+	case Stopped:
+		return HealthStatus{OK: false, Message: "stopped"}
+	case Error:
+		return HealthStatus{OK: false, Message: "error"}
+	default:
+		return HealthStatus{OK: false, Message: "unknown state"}
+	}
+}
+
+// HealthHandler returns an http.Handler that writes the aggregated report as
+// JSON with status 200 if AllOK and 503 otherwise. Suitable for
+// /healthz, /readyz, etc.
+//
+//	http.Handle("/healthz", lifecycle.HealthHandler(componentMgr))
+func HealthHandler(mgr ComponentManager) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scm, ok := mgr.(*SimpleComponentManager)
+		if !ok {
+			http.Error(w, "lifecycle: unsupported ComponentManager", http.StatusInternalServerError)
+			return
+		}
+		report := scm.Health(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		if !report.AllOK() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		_ = json.NewEncoder(w).Encode(report)
+	})
+}

--- a/lifecycle/health_test.go
+++ b/lifecycle/health_test.go
@@ -1,0 +1,136 @@
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// healthyComp is a SimpleComponent that also implements HealthChecker.
+type healthyComp struct {
+	*SimpleComponent
+	checkFn func(ctx context.Context) HealthStatus
+}
+
+func (h *healthyComp) Check(ctx context.Context) HealthStatus { return h.checkFn(ctx) }
+
+func newHealthyComp(id string, fn func(ctx context.Context) HealthStatus) *healthyComp {
+	return &healthyComp{
+		SimpleComponent: &SimpleComponent{
+			CompId:    id,
+			StartFunc: func() error { return nil },
+			StopFunc:  func() error { return nil },
+		},
+		checkFn: fn,
+	}
+}
+
+func TestHealth_HealthCheckerInvoked(t *testing.T) {
+	mgr := NewSimpleComponentManager().(*SimpleComponentManager)
+	a := newHealthyComp("a", func(_ context.Context) HealthStatus { return HealthStatus{OK: true} })
+	mgr.Register(a)
+
+	report := mgr.Health(context.Background())
+	if len(report) != 1 {
+		t.Fatalf("expected 1 entry; got %d", len(report))
+	}
+	if !report["a"].OK {
+		t.Errorf("a should be OK; got %+v", report["a"])
+	}
+}
+
+func TestHealth_NonCheckerFallsBackToState(t *testing.T) {
+	mgr := NewSimpleComponentManager().(*SimpleComponentManager)
+	// Plain SimpleComponent — no HealthChecker.
+	mgr.Register(&SimpleComponent{
+		CompId:    "plain",
+		StartFunc: func() error { return nil },
+		StopFunc:  func() error { return nil },
+	})
+	// State is Unknown by default — should map to OK=false.
+	report := mgr.Health(context.Background())
+	if report["plain"].OK {
+		t.Errorf("non-running plain component should be unhealthy; got %+v", report["plain"])
+	}
+}
+
+func TestHealth_AllOK(t *testing.T) {
+	mgr := NewSimpleComponentManager().(*SimpleComponentManager)
+	mgr.Register(newHealthyComp("a", func(_ context.Context) HealthStatus { return HealthStatus{OK: true} }))
+	mgr.Register(newHealthyComp("b", func(_ context.Context) HealthStatus { return HealthStatus{OK: true} }))
+
+	report := mgr.Health(context.Background())
+	if !report.AllOK() {
+		t.Errorf("expected AllOK; got %+v", report)
+	}
+}
+
+func TestHealth_OneBadFailsAllOK(t *testing.T) {
+	mgr := NewSimpleComponentManager().(*SimpleComponentManager)
+	mgr.Register(newHealthyComp("good", func(_ context.Context) HealthStatus { return HealthStatus{OK: true} }))
+	mgr.Register(newHealthyComp("bad", func(_ context.Context) HealthStatus {
+		return HealthStatus{OK: false, Message: "db unreachable"}
+	}))
+
+	report := mgr.Health(context.Background())
+	if report.AllOK() {
+		t.Errorf("expected !AllOK")
+	}
+	if report["bad"].Message != "db unreachable" {
+		t.Errorf("bad.Message = %q; want db unreachable", report["bad"].Message)
+	}
+}
+
+func TestHealth_LatencyRecorded(t *testing.T) {
+	mgr := NewSimpleComponentManager().(*SimpleComponentManager)
+	mgr.Register(newHealthyComp("a", func(_ context.Context) HealthStatus { return HealthStatus{OK: true} }))
+	report := mgr.Health(context.Background())
+	if report["a"].Latency == 0 {
+		t.Errorf("expected non-zero Latency; got %v", report["a"].Latency)
+	}
+}
+
+func TestHealthHandler_StatusCodes(t *testing.T) {
+	mgr := NewSimpleComponentManager().(*SimpleComponentManager)
+	mgr.Register(newHealthyComp("ok", func(_ context.Context) HealthStatus { return HealthStatus{OK: true} }))
+	srv := httptest.NewServer(HealthHandler(mgr))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("healthy → status = %d, want 200", resp.StatusCode)
+	}
+	var report HealthReport
+	_ = json.NewDecoder(resp.Body).Decode(&report)
+	if !report["ok"].OK {
+		t.Errorf("decoded report missing ok component: %+v", report)
+	}
+
+	// Add an unhealthy one and re-poll.
+	mgr.Register(newHealthyComp("bad", func(_ context.Context) HealthStatus { return HealthStatus{OK: false} }))
+	resp2, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("GET 2: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("unhealthy → status = %d, want 503", resp2.StatusCode)
+	}
+}
+
+func TestHealth_EmptyManager(t *testing.T) {
+	mgr := NewSimpleComponentManager().(*SimpleComponentManager)
+	report := mgr.Health(context.Background())
+	if len(report) != 0 {
+		t.Errorf("empty manager → report should be empty; got %+v", report)
+	}
+	if !report.AllOK() {
+		t.Errorf("empty report should be AllOK (vacuous true)")
+	}
+}


### PR DESCRIPTION
## Description
Adds opt-in `HealthChecker` interface, parallel aggregator, and a ready-to-mount HTTP handler that returns 200/503 plus a JSON report.

### Related Issue
Closes #182

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring
- [x] ✅ Test update
- [ ] 🔨 Build / CI changes

## Changes Made

`lifecycle/health.go` (new, stdlib only):

```go
type HealthStatus struct{ OK bool; Message string; Details map[string]any; Latency time.Duration }
type HealthChecker interface{ Check(ctx context.Context) HealthStatus }
type HealthReport map[string]HealthStatus
func (HealthReport) AllOK() bool
func (*SimpleComponentManager) Health(ctx context.Context) HealthReport
func HealthHandler(mgr ComponentManager) http.Handler   // 200 if AllOK else 503
```

- Probes run **in parallel** per component, each respecting the request `ctx`.
- Snapshot-then-probe: read lock held only for the snapshot, never during `Check` — slow checkers can't block `Register` / `StartAll`.
- Non-checker components fall back to `ComponentState` mapping (`Running` → OK; everything else → not OK with a descriptive message).
- Latency of each `Check` is recorded by the aggregator (not the checker).

## Testing
- [x] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

```
$ go test -race ./lifecycle/...
ok  	oss.nandlabs.io/golly/lifecycle	6.5s
# 7 new tests, all existing tests pass, lint clean
```

## Checklist
- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I agree my contribution may be redistributed under either the [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) license

## Additional Context

**Zero new dependencies** — uses only stdlib (`context`, `encoding/json`, `net/http`, `sync`, `time`).

**Backward compatible** — `ComponentManager` interface is unchanged (no new method required of third-party implementations); `Health` is added on `*SimpleComponentManager` only. Components that don't implement `HealthChecker` still get a sensible status derived from their existing `ComponentState`.
