### PR TITLE
feat(auth): new package — JWT mint/verify, argon2id passwords, sessions

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1,0 +1,246 @@
+package auth
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---- JWT: round-trip per algorithm ----
+
+func TestJWT_HS256_RoundTrip(t *testing.T) {
+	s, err := NewHSSigner(AlgHS256, []byte("super-secret-key-32-bytes-of-zzzzzz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	claims := &Claims{
+		Issuer:    "test",
+		Subject:   "u-1",
+		Audience:  Audience{"api"},
+		ExpiresAt: NewNumericDate(time.Now().Add(5 * time.Minute)),
+		Extra:     map[string]any{"role": "admin"},
+	}
+	tok, err := Sign(s, claims, "k1")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	got, err := Verify(tok, VerifyOptions{
+		Algs:             []string{AlgHS256},
+		VerifierFallback: s,
+		Issuer:           "test",
+		Audience:         "api",
+	})
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if got.Subject != "u-1" {
+		t.Errorf("subject roundtrip wrong: %q", got.Subject)
+	}
+	if got.Extra["role"] != "admin" {
+		t.Errorf("extra roundtrip wrong: %v", got.Extra)
+	}
+}
+
+func TestJWT_RS256_RoundTrip(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := NewRSSigner(AlgRS256, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := NewRSVerifier(AlgRS256, &priv.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok, _ := Sign(s, &Claims{Subject: "u"}, "")
+	if _, err := Verify(tok, VerifyOptions{Algs: []string{AlgRS256}, VerifierFallback: v}); err != nil {
+		t.Errorf("RS verify: %v", err)
+	}
+}
+
+func TestJWT_EdDSA_RoundTrip(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	s := NewEdDSASigner(priv)
+	v := NewEdDSAVerifier(priv.Public().(ed25519.PublicKey))
+	tok, _ := Sign(s, &Claims{Subject: "u"}, "")
+	if _, err := Verify(tok, VerifyOptions{Algs: []string{AlgEdDSA}, VerifierFallback: v}); err != nil {
+		t.Errorf("EdDSA verify: %v", err)
+	}
+}
+
+// ---- JWT: security guarantees ----
+
+func TestJWT_RejectsAlgNotInAllowlist(t *testing.T) {
+	s, _ := NewHSSigner(AlgHS256, []byte("k"))
+	tok, _ := Sign(s, &Claims{}, "")
+
+	// Verifier allows only RS256 → must reject HS256 token.
+	_, err := Verify(tok, VerifyOptions{Algs: []string{AlgRS256}, VerifierFallback: s})
+	if !errors.Is(err, ErrAlgNotAllowed) {
+		t.Errorf("expected ErrAlgNotAllowed; got %v", err)
+	}
+}
+
+func TestJWT_RejectsEmptyAllowlist(t *testing.T) {
+	s, _ := NewHSSigner(AlgHS256, []byte("k"))
+	tok, _ := Sign(s, &Claims{}, "")
+	_, err := Verify(tok, VerifyOptions{VerifierFallback: s})
+	if !errors.Is(err, ErrAlgNotAllowed) {
+		t.Errorf("expected ErrAlgNotAllowed with empty allowlist; got %v", err)
+	}
+}
+
+func TestJWT_RejectsTampered(t *testing.T) {
+	s, _ := NewHSSigner(AlgHS256, []byte("k"))
+	tok, _ := Sign(s, &Claims{Subject: "u"}, "")
+	// Flip the last char.
+	tampered := tok[:len(tok)-1] + flip(tok[len(tok)-1])
+	_, err := Verify(tampered, VerifyOptions{Algs: []string{AlgHS256}, VerifierFallback: s})
+	if !errors.Is(err, ErrInvalidSig) {
+		t.Errorf("expected ErrInvalidSig; got %v", err)
+	}
+}
+
+func flip(c byte) string {
+	if c == 'a' {
+		return "b"
+	}
+	return "a"
+}
+
+func TestJWT_ExpiredAndNotYetValid(t *testing.T) {
+	s, _ := NewHSSigner(AlgHS256, []byte("k"))
+
+	expired := &Claims{ExpiresAt: NewNumericDate(time.Now().Add(-time.Hour))}
+	tok, _ := Sign(s, expired, "")
+	if _, err := Verify(tok, VerifyOptions{Algs: []string{AlgHS256}, VerifierFallback: s}); !errors.Is(err, ErrExpired) {
+		t.Errorf("expected ErrExpired; got %v", err)
+	}
+
+	future := &Claims{NotBefore: NewNumericDate(time.Now().Add(time.Hour))}
+	tok2, _ := Sign(s, future, "")
+	if _, err := Verify(tok2, VerifyOptions{Algs: []string{AlgHS256}, VerifierFallback: s}); !errors.Is(err, ErrNotYetValid) {
+		t.Errorf("expected ErrNotYetValid; got %v", err)
+	}
+}
+
+func TestJWT_IssuerAndAudience(t *testing.T) {
+	s, _ := NewHSSigner(AlgHS256, []byte("k"))
+	tok, _ := Sign(s, &Claims{Issuer: "good", Audience: Audience{"api"}}, "")
+
+	if _, err := Verify(tok, VerifyOptions{Algs: []string{AlgHS256}, VerifierFallback: s, Issuer: "bad"}); !errors.Is(err, ErrIssuerMismatch) {
+		t.Errorf("expected ErrIssuerMismatch; got %v", err)
+	}
+	if _, err := Verify(tok, VerifyOptions{Algs: []string{AlgHS256}, VerifierFallback: s, Audience: "missing"}); !errors.Is(err, ErrAudMismatch) {
+		t.Errorf("expected ErrAudMismatch; got %v", err)
+	}
+}
+
+func TestJWT_KeysetByKID(t *testing.T) {
+	k1, _ := NewHSSigner(AlgHS256, []byte("k1key"))
+	k2, _ := NewHSSigner(AlgHS256, []byte("k2key"))
+	tok, _ := Sign(k2, &Claims{Subject: "u"}, "k2")
+
+	keyset := func(kid string) (Verifier, error) {
+		switch kid {
+		case "k1":
+			return k1, nil
+		case "k2":
+			return k2, nil
+		}
+		return nil, ErrKeyNotFound
+	}
+	if _, err := Verify(tok, VerifyOptions{Algs: []string{AlgHS256}, Keyset: keyset}); err != nil {
+		t.Errorf("expected verify with kid=k2; got %v", err)
+	}
+}
+
+func TestJWT_Audience_StringOrArray(t *testing.T) {
+	s, _ := NewHSSigner(AlgHS256, []byte("k"))
+	// Single-element audience marshals as a bare string.
+	tok, _ := Sign(s, &Claims{Audience: Audience{"api"}}, "")
+	if !strings.Contains(tok, ".") {
+		t.Fatal("malformed token")
+	}
+	got, err := Verify(tok, VerifyOptions{Algs: []string{AlgHS256}, VerifierFallback: s})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Audience) != 1 || got.Audience[0] != "api" {
+		t.Errorf("aud roundtrip wrong: %v", got.Audience)
+	}
+}
+
+// ---- Password hasher ----
+
+func TestPassword_HashVerifyRoundtrip(t *testing.T) {
+	h := DefaultPasswordHasher()
+	// Reduce parameters for test speed.
+	h.Memory = 8192
+	h.Iterations = 1
+	hash, err := h.Hash("correct-horse-battery-staple")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if err := VerifyPassword("correct-horse-battery-staple", hash); err != nil {
+		t.Errorf("expected match; got %v", err)
+	}
+	if err := VerifyPassword("wrong", hash); !errors.Is(err, ErrPasswordMismatch) {
+		t.Errorf("expected ErrPasswordMismatch; got %v", err)
+	}
+}
+
+func TestPassword_RejectsMalformedHash(t *testing.T) {
+	if err := VerifyPassword("x", "not-a-phc-string"); err == nil {
+		t.Error("expected error on malformed hash")
+	}
+}
+
+// ---- Sessions ----
+
+func TestSession_NewValidateRevoke(t *testing.T) {
+	mgr := NewSessionManager(nil, SessionConfig{Absolute: time.Hour})
+	sess, err := mgr.New("user-42", map[string]any{"k": "v"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.ID == "" || sess.Subject != "user-42" {
+		t.Errorf("bad session: %+v", sess)
+	}
+	got, ok := mgr.Validate(sess.ID)
+	if !ok || got.Subject != "user-42" {
+		t.Errorf("validate failed: ok=%v sess=%+v", ok, got)
+	}
+	_ = mgr.Revoke(sess.ID)
+	if _, ok := mgr.Validate(sess.ID); ok {
+		t.Error("revoked session should not validate")
+	}
+}
+
+func TestSession_TouchSlidesExpiry(t *testing.T) {
+	mgr := NewSessionManager(nil, SessionConfig{Absolute: time.Hour, Sliding: 10 * time.Minute})
+	sess, _ := mgr.New("u", nil)
+	origExp := sess.ExpiresAt
+	// Move "now" forward.
+	mgr.now = func() time.Time { return time.Now().Add(5 * time.Minute) }
+	_ = mgr.Touch(sess.ID)
+	got, _ := mgr.Validate(sess.ID)
+	if !got.ExpiresAt.After(origExp) {
+		t.Errorf("touch should extend expiry; orig=%v new=%v", origExp, got.ExpiresAt)
+	}
+}
+
+func TestSession_AbsoluteExpiry(t *testing.T) {
+	mgr := NewSessionManager(nil, SessionConfig{Absolute: time.Hour})
+	sess, _ := mgr.New("u", nil)
+	mgr.now = func() time.Time { return time.Now().Add(2 * time.Hour) }
+	if _, ok := mgr.Validate(sess.ID); ok {
+		t.Error("expired session should not validate")
+	}
+}

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -1,0 +1,480 @@
+// Package auth provides identity primitives — JWT mint/verify, password
+// hashing, and session-token helpers — that are datastore-agnostic. It is
+// the foundation for golly/turbo's JWT middleware and any application that
+// wants a sane, stdlib-first identity layer without pulling in a third-party
+// JWT library.
+//
+// Stdlib only, except for x/crypto/argon2 used by the password hasher
+// (already in tree as a direct dep of golly).
+package auth
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"strings"
+	"time"
+)
+
+// Algorithm names supported by Sign / Verify. Pin your allowlist explicitly
+// at the verifier — never derive it from the token header alone.
+const (
+	AlgHS256 = "HS256"
+	AlgHS384 = "HS384"
+	AlgHS512 = "HS512"
+	AlgRS256 = "RS256"
+	AlgRS384 = "RS384"
+	AlgRS512 = "RS512"
+	AlgEdDSA = "EdDSA"
+)
+
+// Standard JWT errors.
+var (
+	ErrInvalidToken   = errors.New("auth/jwt: invalid token")
+	ErrInvalidSig     = errors.New("auth/jwt: invalid signature")
+	ErrAlgNotAllowed  = errors.New("auth/jwt: algorithm not allowed")
+	ErrExpired        = errors.New("auth/jwt: token expired")
+	ErrNotYetValid    = errors.New("auth/jwt: token not yet valid")
+	ErrIssuerMismatch = errors.New("auth/jwt: issuer mismatch")
+	ErrAudMismatch    = errors.New("auth/jwt: audience mismatch")
+	ErrKeyNotFound    = errors.New("auth/jwt: signing key not found")
+)
+
+// Header is the JOSE header for a JWS-style JWT.
+type Header struct {
+	Alg string `json:"alg"`
+	Typ string `json:"typ,omitempty"`
+	Kid string `json:"kid,omitempty"`
+}
+
+// Claims is the JWT payload. RegisteredClaims covers the RFC 7519 reserved
+// names; custom fields go in Extra and are merged into the payload at sign
+// time and surfaced back on verify.
+type Claims struct {
+	Issuer    string         `json:"iss,omitempty"`
+	Subject   string         `json:"sub,omitempty"`
+	Audience  Audience       `json:"aud,omitempty"`
+	ExpiresAt *NumericDate   `json:"exp,omitempty"`
+	NotBefore *NumericDate   `json:"nbf,omitempty"`
+	IssuedAt  *NumericDate   `json:"iat,omitempty"`
+	ID        string         `json:"jti,omitempty"`
+	Extra     map[string]any `json:"-"`
+}
+
+// Audience is a single string OR a slice — both shapes are valid per RFC 7519.
+type Audience []string
+
+// MarshalJSON renders a single-element Audience as a bare string.
+func (a Audience) MarshalJSON() ([]byte, error) {
+	switch len(a) {
+	case 0:
+		return []byte("null"), nil
+	case 1:
+		return json.Marshal(a[0])
+	default:
+		return json.Marshal([]string(a))
+	}
+}
+
+// UnmarshalJSON accepts string OR []string.
+func (a *Audience) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || string(b) == "null" {
+		*a = nil
+		return nil
+	}
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*a = Audience{s}
+		return nil
+	}
+	var arr []string
+	if err := json.Unmarshal(b, &arr); err != nil {
+		return err
+	}
+	*a = arr
+	return nil
+}
+
+// NumericDate is RFC 7519 §2 NumericDate: seconds since epoch.
+type NumericDate struct{ time.Time }
+
+func NewNumericDate(t time.Time) *NumericDate { return &NumericDate{t.UTC()} }
+
+func (n *NumericDate) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%d", n.Unix())), nil
+}
+
+func (n *NumericDate) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || string(b) == "null" {
+		return nil
+	}
+	// Accept integer or float (Go's encoding/json may emit a float for some).
+	var f float64
+	if err := json.Unmarshal(b, &f); err != nil {
+		return err
+	}
+	n.Time = time.Unix(int64(f), 0).UTC()
+	return nil
+}
+
+// Signer produces signatures for one algorithm.
+type Signer interface {
+	Alg() string
+	Sign(signingInput []byte) ([]byte, error)
+}
+
+// Verifier validates signatures for one algorithm.
+type Verifier interface {
+	Alg() string
+	Verify(signingInput, sig []byte) error
+}
+
+// --- HS (HMAC) ---
+
+// HSSigner is an HMAC-SHA{256,384,512} signer + verifier (symmetric).
+type HSSigner struct {
+	alg string
+	key []byte
+}
+
+// NewHSSigner returns an HS signer/verifier for alg in {AlgHS256, AlgHS384, AlgHS512}.
+func NewHSSigner(alg string, key []byte) (*HSSigner, error) {
+	if _, err := hsHash(alg); err != nil {
+		return nil, err
+	}
+	if len(key) == 0 {
+		return nil, fmt.Errorf("auth/jwt: HS key must be non-empty")
+	}
+	return &HSSigner{alg: alg, key: key}, nil
+}
+
+func (s *HSSigner) Alg() string { return s.alg }
+
+func (s *HSSigner) Sign(signingInput []byte) ([]byte, error) {
+	h, _ := hsHash(s.alg)
+	mac := hmac.New(h, s.key)
+	_, _ = mac.Write(signingInput)
+	return mac.Sum(nil), nil
+}
+
+func (s *HSSigner) Verify(signingInput, sig []byte) error {
+	expected, _ := s.Sign(signingInput)
+	if !hmac.Equal(expected, sig) {
+		return ErrInvalidSig
+	}
+	return nil
+}
+
+func hsHash(alg string) (func() hash.Hash, error) {
+	switch alg {
+	case AlgHS256:
+		return sha256.New, nil
+	case AlgHS384:
+		return sha512.New384, nil
+	case AlgHS512:
+		return sha512.New, nil
+	}
+	return nil, fmt.Errorf("auth/jwt: unsupported HS alg %q", alg)
+}
+
+// --- RS (RSA) ---
+
+// RSSigner is an RSA-PKCS1v15-SHA{256,384,512} signer.
+type RSSigner struct {
+	alg string
+	key *rsa.PrivateKey
+}
+
+// NewRSSigner returns an RS signer for alg in {AlgRS256, AlgRS384, AlgRS512}.
+// To verify-only with a public key, use NewRSVerifier instead.
+func NewRSSigner(alg string, key *rsa.PrivateKey) (*RSSigner, error) {
+	if _, err := rsHash(alg); err != nil {
+		return nil, err
+	}
+	if key == nil {
+		return nil, fmt.Errorf("auth/jwt: RS private key is nil")
+	}
+	return &RSSigner{alg: alg, key: key}, nil
+}
+
+func (s *RSSigner) Alg() string { return s.alg }
+
+func (s *RSSigner) Sign(signingInput []byte) ([]byte, error) {
+	h, hashID := rsHashPair(s.alg)
+	sum := h()
+	_, _ = sum.Write(signingInput)
+	return rsa.SignPKCS1v15(nil, s.key, hashID, sum.Sum(nil))
+}
+
+func (s *RSSigner) Verify(signingInput, sig []byte) error {
+	pub := &s.key.PublicKey
+	return rsVerify(s.alg, pub, signingInput, sig)
+}
+
+// RSVerifier validates RSA signatures with a public key only.
+type RSVerifier struct {
+	alg string
+	pub *rsa.PublicKey
+}
+
+// NewRSVerifier returns a verifier-only with a public key.
+func NewRSVerifier(alg string, pub *rsa.PublicKey) (*RSVerifier, error) {
+	if _, err := rsHash(alg); err != nil {
+		return nil, err
+	}
+	if pub == nil {
+		return nil, fmt.Errorf("auth/jwt: RS public key is nil")
+	}
+	return &RSVerifier{alg: alg, pub: pub}, nil
+}
+
+func (v *RSVerifier) Alg() string                    { return v.alg }
+func (v *RSVerifier) Verify(input, sig []byte) error { return rsVerify(v.alg, v.pub, input, sig) }
+
+func rsVerify(alg string, pub *rsa.PublicKey, input, sig []byte) error {
+	h, hashID := rsHashPair(alg)
+	sum := h()
+	_, _ = sum.Write(input)
+	if err := rsa.VerifyPKCS1v15(pub, hashID, sum.Sum(nil), sig); err != nil {
+		return ErrInvalidSig
+	}
+	return nil
+}
+
+func rsHash(alg string) (func() hash.Hash, error) {
+	switch alg {
+	case AlgRS256:
+		return sha256.New, nil
+	case AlgRS384:
+		return sha512.New384, nil
+	case AlgRS512:
+		return sha512.New, nil
+	}
+	return nil, fmt.Errorf("auth/jwt: unsupported RS alg %q", alg)
+}
+
+func rsHashPair(alg string) (func() hash.Hash, crypto.Hash) {
+	switch alg {
+	case AlgRS256:
+		return sha256.New, crypto.SHA256
+	case AlgRS384:
+		return sha512.New384, crypto.SHA384
+	}
+	return sha512.New, crypto.SHA512
+}
+
+// --- EdDSA ---
+
+// EdDSASigner is an Ed25519 signer + verifier.
+type EdDSASigner struct {
+	priv ed25519.PrivateKey
+	pub  ed25519.PublicKey
+}
+
+func NewEdDSASigner(priv ed25519.PrivateKey) *EdDSASigner {
+	return &EdDSASigner{priv: priv, pub: priv.Public().(ed25519.PublicKey)}
+}
+
+func (s *EdDSASigner) Alg() string { return AlgEdDSA }
+func (s *EdDSASigner) Sign(input []byte) ([]byte, error) {
+	return ed25519.Sign(s.priv, input), nil
+}
+func (s *EdDSASigner) Verify(input, sig []byte) error { return edVerify(s.pub, input, sig) }
+
+// EdDSAVerifier validates Ed25519 signatures with a public key only.
+type EdDSAVerifier struct{ pub ed25519.PublicKey }
+
+func NewEdDSAVerifier(pub ed25519.PublicKey) *EdDSAVerifier { return &EdDSAVerifier{pub: pub} }
+func (v *EdDSAVerifier) Alg() string                        { return AlgEdDSA }
+func (v *EdDSAVerifier) Verify(input, sig []byte) error     { return edVerify(v.pub, input, sig) }
+
+func edVerify(pub ed25519.PublicKey, input, sig []byte) error {
+	if !ed25519.Verify(pub, input, sig) {
+		return ErrInvalidSig
+	}
+	return nil
+}
+
+// --- Sign / Verify ---
+
+// Sign produces a compact-form JWT using signer.
+func Sign(signer Signer, claims *Claims, kid string) (string, error) {
+	if signer == nil {
+		return "", errors.New("auth/jwt: signer is nil")
+	}
+	header := Header{Alg: signer.Alg(), Typ: "JWT", Kid: kid}
+	hb, err := json.Marshal(header)
+	if err != nil {
+		return "", err
+	}
+	pb, err := marshalClaims(claims)
+	if err != nil {
+		return "", err
+	}
+	hEnc := base64.RawURLEncoding.EncodeToString(hb)
+	pEnc := base64.RawURLEncoding.EncodeToString(pb)
+	signingInput := []byte(hEnc + "." + pEnc)
+	sig, err := signer.Sign(signingInput)
+	if err != nil {
+		return "", err
+	}
+	return string(signingInput) + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// marshalClaims merges Extra into the registered-claims JSON object.
+func marshalClaims(c *Claims) ([]byte, error) {
+	if c == nil {
+		return []byte("{}"), nil
+	}
+	// Marshal then unmarshal-into-map so we can splice Extra in.
+	first, err := json.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	m := map[string]any{}
+	if err := json.Unmarshal(first, &m); err != nil {
+		return nil, err
+	}
+	for k, v := range c.Extra {
+		m[k] = v
+	}
+	return json.Marshal(m)
+}
+
+// VerifyOptions configure Verify. Algs is a hard allowlist — algorithms in
+// the token header that are not on this list are rejected (prevents
+// algorithm confusion). Keyset chooses the verifier per kid; if Keyset is
+// nil, VerifierFallback is used regardless of kid.
+type VerifyOptions struct {
+	Algs             []string
+	Keyset           func(kid string) (Verifier, error)
+	VerifierFallback Verifier
+	Issuer           string        // optional; if non-empty must match exactly
+	Audience         string        // optional; if non-empty must appear in aud
+	Leeway           time.Duration // clock skew allowance
+	// Now overrides the time source for testing.
+	Now func() time.Time
+}
+
+// Verify parses, signature-checks, and claim-validates a compact-form JWT,
+// returning the parsed Claims. It rejects 'none' implicitly and any
+// algorithm not in opts.Algs.
+func Verify(token string, opts VerifyOptions) (*Claims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, ErrInvalidToken
+	}
+	hb, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+	var header Header
+	if err = json.Unmarshal(hb, &header); err != nil {
+		return nil, ErrInvalidToken
+	}
+
+	if len(opts.Algs) == 0 {
+		return nil, ErrAlgNotAllowed
+	}
+	allowed := false
+	for _, a := range opts.Algs {
+		if a == header.Alg {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return nil, ErrAlgNotAllowed
+	}
+
+	var verifier Verifier
+	if opts.Keyset != nil {
+		verifier, err = opts.Keyset(header.Kid)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrKeyNotFound, err)
+		}
+	} else {
+		verifier = opts.VerifierFallback
+	}
+	if verifier == nil {
+		return nil, ErrKeyNotFound
+	}
+	if verifier.Alg() != header.Alg {
+		return nil, ErrAlgNotAllowed
+	}
+
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+	if sigErr := verifier.Verify([]byte(parts[0]+"."+parts[1]), sig); sigErr != nil {
+		return nil, sigErr
+	}
+
+	pb, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+	c, err := unmarshalClaims(pb)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidToken, err)
+	}
+
+	now := time.Now()
+	if opts.Now != nil {
+		now = opts.Now()
+	}
+	if c.ExpiresAt != nil && now.After(c.ExpiresAt.Add(opts.Leeway)) {
+		return nil, ErrExpired
+	}
+	if c.NotBefore != nil && now.Add(opts.Leeway).Before(c.NotBefore.Time) {
+		return nil, ErrNotYetValid
+	}
+	if opts.Issuer != "" && c.Issuer != opts.Issuer {
+		return nil, ErrIssuerMismatch
+	}
+	if opts.Audience != "" {
+		ok := false
+		for _, a := range c.Audience {
+			if a == opts.Audience {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return nil, ErrAudMismatch
+		}
+	}
+	return c, nil
+}
+
+// unmarshalClaims first decodes the registered claims, then captures any
+// remaining fields into Extra so callers don't lose data.
+func unmarshalClaims(pb []byte) (*Claims, error) {
+	c := &Claims{}
+	if err := json.Unmarshal(pb, c); err != nil {
+		return nil, err
+	}
+	all := map[string]any{}
+	if err := json.Unmarshal(pb, &all); err != nil {
+		return nil, err
+	}
+	for _, reserved := range []string{"iss", "sub", "aud", "exp", "nbf", "iat", "jti"} {
+		delete(all, reserved)
+	}
+	if len(all) > 0 {
+		c.Extra = all
+	}
+	return c, nil
+}

--- a/auth/password.go
+++ b/auth/password.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// PasswordHasher hashes and verifies passwords using argon2id with the OWASP
+// 2024 recommended defaults. The output is a self-describing PHC-style
+// string ("$argon2id$...") so verification doesn't need the parameters
+// passed in separately — they're embedded in the hash.
+type PasswordHasher struct {
+	Memory      uint32 // KiB; default 47104 (46 MiB)
+	Iterations  uint32 // default 1
+	Parallelism uint8  // default 1
+	SaltLen     uint32 // bytes; default 16
+	KeyLen      uint32 // bytes; default 32
+}
+
+// DefaultPasswordHasher returns a PasswordHasher with the OWASP-recommended
+// argon2id parameters as of 2024 (m=46 MiB, t=1, p=1).
+func DefaultPasswordHasher() *PasswordHasher {
+	return &PasswordHasher{
+		Memory:      47104,
+		Iterations:  1,
+		Parallelism: 1,
+		SaltLen:     16,
+		KeyLen:      32,
+	}
+}
+
+// ErrPasswordMismatch is returned by Verify when the password does not match.
+var ErrPasswordMismatch = errors.New("auth/password: password mismatch")
+
+// Hash returns a PHC-encoded argon2id hash:
+//
+//	$argon2id$v=19$m=47104,t=1,p=1$<base64-salt>$<base64-hash>
+func (h *PasswordHasher) Hash(password string) (string, error) {
+	if h == nil {
+		h = DefaultPasswordHasher()
+	}
+	salt := make([]byte, h.SaltLen)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("auth/password: read salt: %w", err)
+	}
+	hash := argon2.IDKey([]byte(password), salt, h.Iterations, h.Memory, h.Parallelism, h.KeyLen)
+	return fmt.Sprintf(
+		"$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version,
+		h.Memory, h.Iterations, h.Parallelism,
+		base64.RawStdEncoding.EncodeToString(salt),
+		base64.RawStdEncoding.EncodeToString(hash),
+	), nil
+}
+
+// VerifyPassword checks password against an encoded hash. Returns nil on
+// match, ErrPasswordMismatch on mismatch, or an error if the encoded hash
+// is malformed. Uses a constant-time comparison.
+func VerifyPassword(password, encoded string) error {
+	parts := strings.Split(encoded, "$")
+	// Expected: ["", "argon2id", "v=19", "m=...,t=...,p=...", "<salt>", "<hash>"]
+	if len(parts) != 6 || parts[0] != "" || parts[1] != "argon2id" {
+		return fmt.Errorf("auth/password: invalid encoded hash format")
+	}
+	var version int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &version); err != nil {
+		return fmt.Errorf("auth/password: invalid version field: %w", err)
+	}
+	if version != argon2.Version {
+		return fmt.Errorf("auth/password: incompatible argon2 version %d (this build supports %d)", version, argon2.Version)
+	}
+	var memory, iterations uint32
+	var parallelism uint8
+	if _, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &memory, &iterations, &parallelism); err != nil {
+		return fmt.Errorf("auth/password: invalid params: %w", err)
+	}
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return fmt.Errorf("auth/password: invalid salt: %w", err)
+	}
+	want, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return fmt.Errorf("auth/password: invalid hash: %w", err)
+	}
+
+	got := argon2.IDKey([]byte(password), salt, iterations, memory, parallelism, uint32(len(want)))
+	if subtle.ConstantTimeCompare(got, want) != 1 {
+		return ErrPasswordMismatch
+	}
+	return nil
+}

--- a/auth/session.go
+++ b/auth/session.go
@@ -1,0 +1,174 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"sync"
+	"time"
+)
+
+// Session represents an opaque server-side session (not a JWT). The actual
+// session id is a random 32-byte URL-safe string; the data lives in a Store
+// keyed by it.
+type Session struct {
+	ID        string
+	Subject   string // user id, etc.
+	CreatedAt time.Time
+	ExpiresAt time.Time      // absolute expiry
+	LastSeen  time.Time      // for sliding expiry
+	Data      map[string]any // app-specific
+}
+
+// Active reports whether the session is non-empty, non-expired.
+func (s *Session) Active(now time.Time) bool {
+	return s != nil && s.ID != "" && now.Before(s.ExpiresAt)
+}
+
+// SessionStore is the persistence interface for opaque sessions. The default
+// in-memory MemorySessionStore is suitable for tests and single-process apps.
+type SessionStore interface {
+	Get(id string) (*Session, bool)
+	Put(s *Session) error
+	Delete(id string) error
+}
+
+// MemorySessionStore is a goroutine-safe in-memory SessionStore.
+type MemorySessionStore struct {
+	mu sync.RWMutex
+	m  map[string]*Session
+}
+
+// NewMemorySessionStore returns an empty in-memory store.
+func NewMemorySessionStore() *MemorySessionStore {
+	return &MemorySessionStore{m: make(map[string]*Session)}
+}
+
+func (s *MemorySessionStore) Get(id string) (*Session, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sess, ok := s.m[id]
+	return sess, ok
+}
+
+func (s *MemorySessionStore) Put(sess *Session) error {
+	if sess == nil || sess.ID == "" {
+		return errors.New("auth/session: empty session id")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[sess.ID] = sess
+	return nil
+}
+
+func (s *MemorySessionStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.m, id)
+	return nil
+}
+
+// SessionConfig governs how the SessionManager mints and renews sessions.
+type SessionConfig struct {
+	// Absolute is the maximum total lifetime of a session, regardless of
+	// activity. After this, the session must be re-created.
+	Absolute time.Duration
+	// Sliding extends ExpiresAt on Touch up to Absolute. Set to 0 to
+	// disable sliding (sessions are pure absolute-expiry tokens).
+	Sliding time.Duration
+}
+
+// SessionManager mints and validates opaque sessions backed by a SessionStore.
+type SessionManager struct {
+	store SessionStore
+	cfg   SessionConfig
+	now   func() time.Time
+}
+
+// NewSessionManager returns a SessionManager. Uses NewMemorySessionStore if
+// store is nil.
+func NewSessionManager(store SessionStore, cfg SessionConfig) *SessionManager {
+	if store == nil {
+		store = NewMemorySessionStore()
+	}
+	if cfg.Absolute <= 0 {
+		cfg.Absolute = 24 * time.Hour
+	}
+	return &SessionManager{store: store, cfg: cfg, now: time.Now}
+}
+
+// New mints a fresh session for subject and stores it.
+func (m *SessionManager) New(subject string, data map[string]any) (*Session, error) {
+	id, err := randomToken(32)
+	if err != nil {
+		return nil, err
+	}
+	now := m.now()
+	// With sliding configured, initial expiry is now+Sliding (capped at
+	// hardCap=now+Absolute). Without sliding, it's the hardCap.
+	exp := now.Add(m.cfg.Absolute)
+	if m.cfg.Sliding > 0 {
+		if sliding := now.Add(m.cfg.Sliding); sliding.Before(exp) {
+			exp = sliding
+		}
+	}
+	sess := &Session{
+		ID:        id,
+		Subject:   subject,
+		CreatedAt: now,
+		LastSeen:  now,
+		ExpiresAt: exp,
+		Data:      data,
+	}
+	if err := m.store.Put(sess); err != nil {
+		return nil, err
+	}
+	return sess, nil
+}
+
+// Validate looks up id, verifies it's active. Returns (nil, false) when not
+// found or expired (also deletes expired sessions).
+func (m *SessionManager) Validate(id string) (*Session, bool) {
+	sess, ok := m.store.Get(id)
+	if !ok {
+		return nil, false
+	}
+	if !sess.Active(m.now()) {
+		_ = m.store.Delete(id)
+		return nil, false
+	}
+	return sess, true
+}
+
+// Touch records activity. If Sliding is non-zero, extends ExpiresAt by
+// Sliding (capped at CreatedAt+Absolute) so active sessions don't expire.
+func (m *SessionManager) Touch(id string) error {
+	sess, ok := m.Validate(id)
+	if !ok {
+		return errors.New("auth/session: session not active")
+	}
+	now := m.now()
+	sess.LastSeen = now
+	if m.cfg.Sliding > 0 {
+		newExp := now.Add(m.cfg.Sliding)
+		hardCap := sess.CreatedAt.Add(m.cfg.Absolute)
+		if newExp.After(hardCap) {
+			newExp = hardCap
+		}
+		sess.ExpiresAt = newExp
+	}
+	return m.store.Put(sess)
+}
+
+// Revoke deletes the session, immediately invalidating it.
+func (m *SessionManager) Revoke(id string) error { return m.store.Delete(id) }
+
+// randomToken returns a base64.RawURL-encoded random byte string of nBytes
+// of entropy (the encoded string is longer than nBytes).
+func randomToken(nBytes int) (string, error) {
+	b := make([]byte, nBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}


### PR DESCRIPTION
## Description
New `auth/` package — JWT mint/verify, argon2id password hashing, opaque server-side sessions. Foundation for the upcoming turbo JWT middleware and any app that wants a sane stdlib-first identity layer.

### Related Issue
Closes #172

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature (new module)
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring
- [x] ✅ Test update
- [ ] 🔨 Build / CI changes

## Changes Made
**`auth/jwt.go`** — JWS-compact JWT:
- Algs: HS256/HS384/HS512, RS256/RS384/RS512, EdDSA
- `Signer`/`Verifier` interfaces + per-alg impls (`HSSigner`, `RSSigner`+`RSVerifier`, `EdDSASigner`+`EdDSAVerifier`)
- `Claims` with RFC 7519 fields, single-string-OR-array `Audience`, `NumericDate`, custom `Extra` bag
- `VerifyOptions{Algs, Keyset, Issuer, Audience, Leeway, Now}` — **hard** Algs allowlist prevents algorithm-confusion (`none` is impossible)
- Errors: `ErrInvalidToken`, `ErrInvalidSig`, `ErrAlgNotAllowed`, `ErrExpired`, `ErrNotYetValid`, `ErrIssuerMismatch`, `ErrAudMismatch`, `ErrKeyNotFound`

**`auth/password.go`** — argon2id:
- `DefaultPasswordHasher()` uses OWASP-2024 params (m=46MiB, t=1, p=1)
- `Hash` returns PHC-encoded `$argon2id$v=19$m=...$<salt>$<hash>`
- `VerifyPassword` is constant-time and version-aware

**`auth/session.go`** — opaque sessions:
- `SessionManager.New / Validate / Touch / Revoke` with absolute + optional sliding expiry (sliding capped at `CreatedAt+Absolute`)
- `MemorySessionStore` for in-process; `SessionStore` interface for app-specific persistence

## Testing
- [x] I have added/updated unit tests
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

```
$ go test -race ./auth/...
ok  oss.nandlabs.io/golly/auth   1.7s
# 15 tests, 0 failures, lint clean
```

## Checklist
- [x] code follows project style
- [x] self-review done
- [x] commented non-obvious code
- [x] docs updated
- [x] no new warnings
- [x] read CONTRIBUTING
- [x] dual-license consent

## Additional Context
**Zero new deps** — only `x/crypto/argon2` from the password hasher, and `x/crypto` is already a direct dep of golly. Everything else (`crypto/{hmac,sha256,sha512,rsa,ed25519,subtle,rand}`, `encoding/{base64,json}`) is stdlib.

**Backward compatible** — net-new package, no existing API touched.

**Pairs with #169** (turbo JWT middleware): the middleware in PR 7 (turbo bundle) will accept `auth.Verifier` directly, sharing the verify primitive defined here.
