### PR TITLE
feat(turbo): SSE helper + JWT middleware + rate limit + route groups

### DIFF
--- a/turbo/auth/jwt.go
+++ b/turbo/auth/jwt.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// VerifyFunc is the user-supplied function that validates a raw token and
+// returns the authenticated claims (whatever type fits the app — typically
+// *jwt.Claims from golly/auth). Returning an error rejects the request with
+// 401.
+//
+// Keeping this as a callback (not a hard import on golly/auth) lets turbo
+// stay decoupled from any specific JWT library and lets consumers pin the
+// allowlist of algorithms / issuers / audiences themselves.
+type VerifyFunc func(token string) (claims any, err error)
+
+// JWTConfig configures the JWT authenticator. Verify is required; the rest
+// have sane defaults.
+type JWTConfig struct {
+	Verify     VerifyFunc
+	HeaderName string // default: Authorization
+	Scheme     string // default: Bearer  (set "" to take the whole header value)
+	ContextKey any    // where validated claims are stashed; defaults to claimsContextKey{}
+	OnError    func(w http.ResponseWriter, r *http.Request, err error)
+	OnMissing  func(w http.ResponseWriter, r *http.Request)
+}
+
+// Errors raised by the JWT authenticator.
+var (
+	ErrMissingAuthHeader = errors.New("turbo/auth/jwt: missing Authorization header")
+	ErrWrongScheme       = errors.New("turbo/auth/jwt: wrong authorization scheme")
+	ErrEmptyToken        = errors.New("turbo/auth/jwt: empty token")
+)
+
+// claimsContextKey is the default key used when the caller doesn't supply one.
+type claimsContextKey struct{}
+
+// JWT returns an Authenticator that extracts a bearer token from the
+// configured header, runs Verify(token), and on success injects the claims
+// into the request context. On failure it writes 401 (or calls the
+// OnError/OnMissing override).
+func JWT(cfg JWTConfig) Authenticator {
+	if cfg.Verify == nil {
+		panic("turbo/auth/jwt: Verify is required")
+	}
+	if cfg.HeaderName == "" {
+		cfg.HeaderName = "Authorization"
+	}
+	scheme := strings.TrimSpace(cfg.Scheme)
+	if cfg.Scheme == "" {
+		scheme = "Bearer"
+	}
+	ckey := cfg.ContextKey
+	if ckey == nil {
+		ckey = claimsContextKey{}
+	}
+	onErr := cfg.OnError
+	if onErr == nil {
+		onErr = defaultOnError
+	}
+	onMissing := cfg.OnMissing
+	if onMissing == nil {
+		onMissing = func(w http.ResponseWriter, r *http.Request) {
+			defaultOnError(w, r, ErrMissingAuthHeader)
+		}
+	}
+
+	return &jwtAuthenticator{
+		verify:     cfg.Verify,
+		header:     cfg.HeaderName,
+		scheme:     scheme,
+		contextKey: ckey,
+		onError:    onErr,
+		onMissing:  onMissing,
+	}
+}
+
+// ClaimsFrom retrieves claims previously stashed by JWT(...) from the
+// request context. The second return is false if no claims are present.
+//
+// If you used a custom ContextKey, call ctx.Value(myKey) directly instead.
+func ClaimsFrom(ctx context.Context) (any, bool) {
+	v := ctx.Value(claimsContextKey{})
+	return v, v != nil
+}
+
+// jwtAuthenticator implements Authenticator.
+type jwtAuthenticator struct {
+	verify     VerifyFunc
+	header     string
+	scheme     string
+	contextKey any
+	onError    func(w http.ResponseWriter, r *http.Request, err error)
+	onMissing  func(w http.ResponseWriter, r *http.Request)
+}
+
+func (a *jwtAuthenticator) Apply(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw := r.Header.Get(a.header)
+		if raw == "" {
+			a.onMissing(w, r)
+			return
+		}
+		token := raw
+		if a.scheme != "" {
+			prefix := a.scheme + " "
+			if !strings.HasPrefix(raw, prefix) {
+				a.onError(w, r, ErrWrongScheme)
+				return
+			}
+			token = strings.TrimSpace(raw[len(prefix):])
+		}
+		if token == "" {
+			a.onError(w, r, ErrEmptyToken)
+			return
+		}
+		claims, err := a.verify(token)
+		if err != nil {
+			a.onError(w, r, err)
+			return
+		}
+		ctx := context.WithValue(r.Context(), a.contextKey, claims)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func defaultOnError(w http.ResponseWriter, _ *http.Request, err error) {
+	http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
+}

--- a/turbo/auth/jwt_test.go
+++ b/turbo/auth/jwt_test.go
@@ -1,0 +1,114 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type fakeClaims struct{ user string }
+
+func TestJWT_OK(t *testing.T) {
+	a := JWT(JWTConfig{
+		Verify: func(tok string) (any, error) {
+			if tok != "good" {
+				return nil, errors.New("nope")
+			}
+			return &fakeClaims{user: "alice"}, nil
+		},
+	})
+	called := false
+	h := a.Apply(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		v, ok := ClaimsFrom(r.Context())
+		if !ok {
+			t.Errorf("claims missing from ctx")
+		}
+		if c, ok := v.(*fakeClaims); !ok || c.user != "alice" {
+			t.Errorf("claims wrong: %v", v)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer good")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if !called {
+		t.Error("downstream handler was not invoked")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestJWT_MissingHeaderUnauthorized(t *testing.T) {
+	a := JWT(JWTConfig{Verify: func(string) (any, error) { return nil, nil }})
+	w := httptest.NewRecorder()
+	a.Apply(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("handler should not run")
+	})).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestJWT_WrongScheme(t *testing.T) {
+	a := JWT(JWTConfig{Verify: func(string) (any, error) { return nil, nil }})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Basic xyz")
+	w := httptest.NewRecorder()
+	a.Apply(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})).ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Basic scheme should be rejected; status = %d", w.Code)
+	}
+}
+
+func TestJWT_VerifyFails(t *testing.T) {
+	a := JWT(JWTConfig{
+		Verify: func(tok string) (any, error) { return nil, errors.New("bad sig") },
+	})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer x")
+	w := httptest.NewRecorder()
+	a.Apply(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Error("must not run") })).ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestJWT_CustomScheme(t *testing.T) {
+	a := JWT(JWTConfig{
+		Scheme: "Token",
+		Verify: func(tok string) (any, error) { return tok, nil },
+	})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Token abc123")
+	w := httptest.NewRecorder()
+	a.Apply(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(w, r)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", w.Code)
+	}
+}
+
+func TestJWT_CustomContextKey(t *testing.T) {
+	type myKey struct{}
+	a := JWT(JWTConfig{
+		ContextKey: myKey{},
+		Verify:     func(tok string) (any, error) { return "claims!", nil },
+	})
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer x")
+	w := httptest.NewRecorder()
+	a.Apply(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		if v := r.Context().Value(myKey{}); v != "claims!" {
+			t.Errorf("custom key value wrong: %v", v)
+		}
+		// Default ClaimsFrom should miss the value (different key).
+		if _, ok := ClaimsFrom(r.Context()); ok {
+			t.Error("default ClaimsFrom should miss the custom key")
+		}
+	})).ServeHTTP(w, r)
+}

--- a/turbo/filters/ratelimit.go
+++ b/turbo/filters/ratelimit.go
@@ -1,0 +1,144 @@
+package filters
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RateLimitConfig configures the per-principal token-bucket rate limiter.
+//
+// Tokens-per-second + Burst control the bucket; Principal extracts the
+// rate-limit key from a request (user id, API key, remote IP, etc.). If
+// Principal returns an empty string the request is allowed through
+// unconditionally — useful for letting unauthenticated paths bypass.
+type RateLimitConfig struct {
+	// Rate is the steady-state tokens per second added to each bucket.
+	Rate float64
+	// Burst is the maximum bucket size (and the per-key initial tokens).
+	Burst int
+	// Principal extracts the rate-limit key. The default keys by
+	// req.RemoteAddr — useful for naïve IP throttling but typically you
+	// want to swap this for an auth-derived key.
+	Principal func(r *http.Request) string
+	// OnLimit is called when a request is rejected. Defaults to writing
+	// 429 with a Retry-After header equal to the time until the next token.
+	OnLimit func(w http.ResponseWriter, r *http.Request, retryAfter time.Duration)
+	// Now overrides the time source (testing).
+	Now func() time.Time
+}
+
+// RateLimit returns an http middleware that enforces a token-bucket policy.
+// State is held in process — for distributed deployments wire up a store
+// that satisfies the unexported bucketStore interface (extension point
+// reserved; see roadmap).
+//
+//	router.AddGlobalFilter(filters.RateLimit(filters.RateLimitConfig{
+//	    Rate:      5,        // 5 requests/sec steady state
+//	    Burst:     20,       // bucket size
+//	    Principal: filters.PrincipalFromHeader("X-User-Id"),
+//	}))
+func RateLimit(cfg RateLimitConfig) func(http.Handler) http.Handler {
+	if cfg.Rate <= 0 {
+		panic("turbo/filters: RateLimit Rate must be > 0")
+	}
+	if cfg.Burst <= 0 {
+		cfg.Burst = 1
+	}
+	if cfg.Principal == nil {
+		cfg.Principal = func(r *http.Request) string { return r.RemoteAddr }
+	}
+	if cfg.OnLimit == nil {
+		cfg.OnLimit = defaultOnLimit
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+
+	store := &memBucketStore{
+		rate:    cfg.Rate,
+		burst:   float64(cfg.Burst),
+		now:     cfg.Now,
+		buckets: make(map[string]*bucket),
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := cfg.Principal(r)
+			if key == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if ok, retryAfter := store.take(key); !ok {
+				cfg.OnLimit(w, r, retryAfter)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// PrincipalFromHeader returns a Principal extractor that reads the given
+// header. Empty/missing → empty key (the request bypasses the limiter).
+func PrincipalFromHeader(name string) func(*http.Request) string {
+	return func(r *http.Request) string {
+		return strings.TrimSpace(r.Header.Get(name))
+	}
+}
+
+// --- internals ---
+
+type bucket struct {
+	tokens float64
+	last   time.Time
+}
+
+type memBucketStore struct {
+	mu      sync.Mutex
+	rate    float64
+	burst   float64
+	now     func() time.Time
+	buckets map[string]*bucket
+}
+
+// take attempts to remove one token from key's bucket. Returns
+// (allowed, retryAfter). retryAfter is 0 when allowed.
+func (s *memBucketStore) take(key string) (bool, time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	b, ok := s.buckets[key]
+	if !ok {
+		b = &bucket{tokens: s.burst, last: now}
+		s.buckets[key] = b
+	}
+	// Refill.
+	elapsed := now.Sub(b.last).Seconds()
+	if elapsed > 0 {
+		b.tokens += elapsed * s.rate
+		if b.tokens > s.burst {
+			b.tokens = s.burst
+		}
+		b.last = now
+	}
+	if b.tokens >= 1 {
+		b.tokens--
+		return true, 0
+	}
+	// Compute when the next token arrives.
+	need := 1 - b.tokens
+	seconds := need / s.rate
+	return false, time.Duration(seconds * float64(time.Second))
+}
+
+func defaultOnLimit(w http.ResponseWriter, _ *http.Request, retryAfter time.Duration) {
+	secs := int(retryAfter.Seconds())
+	if secs < 1 {
+		secs = 1
+	}
+	w.Header().Set("Retry-After", strconv.Itoa(secs))
+	http.Error(w, fmt.Sprintf("rate limit exceeded; retry after %ds", secs), http.StatusTooManyRequests)
+}

--- a/turbo/filters/ratelimit_test.go
+++ b/turbo/filters/ratelimit_test.go
@@ -1,0 +1,108 @@
+package filters
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRateLimit_BurstAndRefill(t *testing.T) {
+	now := time.Unix(0, 0)
+	mw := RateLimit(RateLimitConfig{
+		Rate:      1, // 1 token/sec
+		Burst:     3,
+		Principal: PrincipalFromHeader("X-User"),
+		Now:       func() time.Time { return now },
+	})
+	var served int32
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&served, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First 3 requests within burst should all succeed.
+	for i := 0; i < 3; i++ {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("X-User", "alice")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("req %d: status = %d, want 200", i, w.Code)
+		}
+	}
+	// 4th should be rejected.
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-User", "alice")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("4th req: status = %d, want 429", w.Code)
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("Retry-After header missing on 429")
+	}
+	// Advance time by 1.1s — one token refilled — next should pass.
+	now = now.Add(1100 * time.Millisecond)
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-User", "alice")
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("after refill: status = %d, want 200", w.Code)
+	}
+	if atomic.LoadInt32(&served) != 4 {
+		t.Errorf("served = %d, want 4", served)
+	}
+}
+
+func TestRateLimit_PerPrincipalIsolation(t *testing.T) {
+	mw := RateLimit(RateLimitConfig{
+		Rate:      0.001, // basically frozen
+		Burst:     1,
+		Principal: PrincipalFromHeader("X-User"),
+	})
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	// alice spends her token.
+	w1 := httptest.NewRecorder()
+	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r1.Header.Set("X-User", "alice")
+	h.ServeHTTP(w1, r1)
+	if w1.Code != 200 {
+		t.Fatalf("alice 1: %d", w1.Code)
+	}
+	// alice's 2nd is denied.
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2.Header.Set("X-User", "alice")
+	h.ServeHTTP(w2, r2)
+	if w2.Code != http.StatusTooManyRequests {
+		t.Errorf("alice 2: %d, want 429", w2.Code)
+	}
+	// bob is independent.
+	w3 := httptest.NewRecorder()
+	r3 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r3.Header.Set("X-User", "bob")
+	h.ServeHTTP(w3, r3)
+	if w3.Code != 200 {
+		t.Errorf("bob 1: %d, want 200", w3.Code)
+	}
+}
+
+func TestRateLimit_EmptyPrincipalBypass(t *testing.T) {
+	mw := RateLimit(RateLimitConfig{
+		Rate:      0.001,
+		Burst:     1,
+		Principal: func(r *http.Request) string { return "" }, // always empty
+	})
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }))
+	for i := 0; i < 10; i++ {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		if w.Code != http.StatusOK {
+			t.Errorf("req %d: status = %d, want 200 (empty principal should bypass)", i, w.Code)
+		}
+	}
+}

--- a/turbo/group.go
+++ b/turbo/group.go
@@ -1,0 +1,161 @@
+package turbo
+
+import (
+	"net/http"
+	"strings"
+
+	"oss.nandlabs.io/golly/turbo/auth"
+)
+
+// Group is a routing prefix with its own stack of filters / authenticator.
+// Groups make it easy to attach middleware to a whole subtree of routes
+// (e.g. "/api/v1" with JWT auth) without repeating boilerplate on every
+// route registration.
+//
+// Construct via Router.Group; nested groups are allowed and compose
+// prefixes + filters in declaration order.
+type Group struct {
+	router  *Router
+	parent  *Group
+	prefix  string
+	filters []FilterFunc
+	auth    auth.Authenticator
+}
+
+// Group returns a child Group rooted at prefix. The prefix is concatenated
+// with any parent prefix; filters and authenticators added on the parent
+// are inherited.
+//
+//	api := router.Group("/api/v1")
+//	api.Use(myLogger)
+//	api.AddAuthenticator(jwtAuth)
+//	api.Get("/users/:id", listUser)         // → GET /api/v1/users/:id
+//	admin := api.Group("/admin")
+//	admin.Get("/audit", listAudit)          // → GET /api/v1/admin/audit (still authed)
+func (router *Router) Group(prefix string) *Group {
+	return &Group{router: router, prefix: normalizeGroupPrefix(prefix)}
+}
+
+// Group on a Group returns a nested Group whose prefix and filters compose
+// with the parent's.
+func (g *Group) Group(prefix string) *Group {
+	return &Group{router: g.router, parent: g, prefix: normalizeGroupPrefix(prefix)}
+}
+
+// Use appends one or more filters that will be applied to every route
+// registered *after* this call on this Group (and any nested children).
+// Returns the Group for chaining.
+func (g *Group) Use(filters ...FilterFunc) *Group {
+	g.filters = append(g.filters, filters...)
+	return g
+}
+
+// AddAuthenticator sets the authenticator for every route registered on
+// this Group (and nested children that don't override it).
+func (g *Group) AddAuthenticator(a auth.Authenticator) *Group {
+	g.auth = a
+	return g
+}
+
+// Get / Post / Put / Delete register handlers with the group's prefix
+// applied; the group's filters + authenticator are attached automatically.
+func (g *Group) Get(path string, h func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return g.add(path, h, GET)
+}
+func (g *Group) Post(path string, h func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return g.add(path, h, POST)
+}
+func (g *Group) Put(path string, h func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return g.add(path, h, PUT)
+}
+func (g *Group) Delete(path string, h func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return g.add(path, h, DELETE)
+}
+
+// Add registers an arbitrary method handler (or methods) on this Group.
+func (g *Group) Add(path string, h func(w http.ResponseWriter, r *http.Request), methods ...string) (*Route, error) {
+	return g.add(path, h, methods...)
+}
+
+func (g *Group) add(path string, h func(w http.ResponseWriter, r *http.Request), methods ...string) (*Route, error) {
+	full := g.fullPath(path)
+	route, err := g.router.Add(full, h, methods...)
+	if err != nil {
+		return nil, err
+	}
+	// Apply collected filters in chain order (root → leaf).
+	for _, f := range g.collectFilters() {
+		route.AddFilter(f)
+	}
+	if a := g.effectiveAuth(); a != nil {
+		route.AddAuthenticator(a)
+	}
+	return route, nil
+}
+
+// fullPath concatenates all parent group prefixes with this group's prefix
+// and the per-route path.
+func (g *Group) fullPath(path string) string {
+	parts := []string{}
+	for cur := g; cur != nil; cur = cur.parent {
+		if cur.prefix != "" {
+			parts = append([]string{cur.prefix}, parts...)
+		}
+	}
+	parts = append(parts, normalizeRoutePath(path))
+	joined := strings.Join(parts, "")
+	if joined == "" {
+		joined = "/"
+	}
+	return joined
+}
+
+// collectFilters returns the parent-then-self filter list.
+func (g *Group) collectFilters() []FilterFunc {
+	if g.parent == nil {
+		return g.filters
+	}
+	pf := g.parent.collectFilters()
+	out := make([]FilterFunc, 0, len(pf)+len(g.filters))
+	out = append(out, pf...)
+	out = append(out, g.filters...)
+	return out
+}
+
+// effectiveAuth returns this Group's authenticator if set, else the
+// nearest ancestor's.
+func (g *Group) effectiveAuth() auth.Authenticator {
+	if g.auth != nil {
+		return g.auth
+	}
+	if g.parent != nil {
+		return g.parent.effectiveAuth()
+	}
+	return nil
+}
+
+// normalizeGroupPrefix ensures the prefix starts with "/" and does not end
+// with "/" (so concatenation with "/path" produces "/prefix/path").
+func normalizeGroupPrefix(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" || p == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	p = strings.TrimRight(p, "/")
+	return p
+}
+
+// normalizeRoutePath ensures the path starts with "/".
+func normalizeRoutePath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return p
+}

--- a/turbo/group_test.go
+++ b/turbo/group_test.go
@@ -1,0 +1,114 @@
+package turbo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestGroup_PrefixConcatenated(t *testing.T) {
+	r := NewRouter()
+	api := r.Group("/api/v1")
+	_, err := api.Get("/users/:id", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/api/v1/users/42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	// And not at the un-prefixed path.
+	resp2, err := http.Get(srv.URL + "/users/42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode == http.StatusOK {
+		t.Error("un-prefixed path should not be served")
+	}
+}
+
+func TestGroup_NestedGroupComposesPrefixes(t *testing.T) {
+	r := NewRouter()
+	api := r.Group("/api")
+	v1 := api.Group("/v1")
+	_, _ = v1.Get("/ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/api/v1/ping")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("nested group prefix not applied; status = %d", resp.StatusCode)
+	}
+}
+
+func TestGroup_FiltersInheritedFromParent(t *testing.T) {
+	r := NewRouter()
+	var calls int32
+	mark := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			next.ServeHTTP(w, r)
+		})
+	}
+	api := r.Group("/api").Use(mark)
+	v1 := api.Group("/v1")
+	_, _ = v1.Get("/x", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	for i := 0; i < 3; i++ {
+		resp, _ := http.Get(srv.URL + "/api/v1/x")
+		resp.Body.Close()
+	}
+	if atomic.LoadInt32(&calls) != 3 {
+		t.Errorf("filter calls = %d, want 3 (parent's filter must apply on nested-group routes)", calls)
+	}
+}
+
+func TestGroup_AuthenticatorAppliedToGroup(t *testing.T) {
+	r := NewRouter()
+	var seen int32
+	stub := stubAuth(func() { atomic.AddInt32(&seen, 1) })
+	api := r.Group("/api")
+	api.AddAuthenticator(stub)
+	_, _ = api.Get("/x", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	resp, _ := http.Get(srv.URL + "/api/x")
+	resp.Body.Close()
+	if atomic.LoadInt32(&seen) != 1 {
+		t.Errorf("group authenticator not invoked: seen=%d", seen)
+	}
+}
+
+// --- helpers ---
+
+type stubAuthenticator struct{ before func() }
+
+func (s stubAuthenticator) Apply(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.before()
+		next.ServeHTTP(w, r)
+	})
+}
+
+func stubAuth(before func()) stubAuthenticator { return stubAuthenticator{before: before} }

--- a/turbo/sse.go
+++ b/turbo/sse.go
@@ -1,0 +1,154 @@
+package turbo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+// SSEWriter is a thin wrapper around http.ResponseWriter that emits
+// Server-Sent Events. Construct one per request via NewSSE; it sets the
+// proper headers and wraps the underlying http.Flusher so each Send is
+// immediately pushed to the client.
+//
+// Typical usage:
+//
+//	router.Get("/events", func(w http.ResponseWriter, r *http.Request) {
+//	    sse, err := turbo.NewSSE(w)
+//	    if err != nil { /* handler doesn't support Flusher */ return }
+//	    defer sse.Close()
+//	    for token := range tokens(r.Context()) {
+//	        if err := sse.Send("token", token); err != nil { return }
+//	    }
+//	})
+type SSEWriter struct {
+	mu      sync.Mutex
+	w       http.ResponseWriter
+	flusher http.Flusher
+	closed  bool
+}
+
+// ErrUnflushable is returned by NewSSE when the response writer doesn't
+// implement http.Flusher (e.g. wrapped in a buffering middleware).
+var ErrUnflushable = errors.New("turbo/sse: response writer does not support flushing")
+
+// NewSSE wraps w as an SSEWriter. It sets headers (Content-Type:
+// text/event-stream, Cache-Control: no-cache, Connection: keep-alive,
+// X-Accel-Buffering: no) and writes them immediately so proxies don't
+// buffer the stream.
+func NewSSE(w http.ResponseWriter) (*SSEWriter, error) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return nil, ErrUnflushable
+	}
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no") // disable nginx proxy buffering
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+	return &SSEWriter{w: w, flusher: flusher}, nil
+}
+
+// Send emits an SSE event. event is the event name (empty for default).
+// data is JSON-marshaled; strings/[]byte are written verbatim to preserve
+// caller formatting (useful for line-multiline payloads).
+//
+// Wire format per event:
+//
+//	event: <event>\n
+//	data:  <line1>\n
+//	data:  <line2>\n
+//	\n
+func (s *SSEWriter) Send(event string, data any) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return errors.New("turbo/sse: writer closed")
+	}
+	if event != "" {
+		if _, err := fmt.Fprintf(s.w, "event: %s\n", event); err != nil {
+			return err
+		}
+	}
+	body, err := dataToString(data)
+	if err != nil {
+		return err
+	}
+	// SSE: each line of data must be prefixed with "data: ".
+	for line := range splitLines(body) {
+		if _, err := fmt.Fprintf(s.w, "data: %s\n", line); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprint(s.w, "\n"); err != nil {
+		return err
+	}
+	s.flusher.Flush()
+	return nil
+}
+
+// Flush forces a flush of the underlying writer. Send already flushes after
+// each event; this is for use after manual writes via Raw().
+func (s *SSEWriter) Flush() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.closed {
+		s.flusher.Flush()
+	}
+}
+
+// Close marks the writer closed and emits a terminal "event: close" so
+// well-behaved EventSource clients stop reconnecting.
+func (s *SSEWriter) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return nil
+	}
+	_, _ = fmt.Fprint(s.w, "event: close\ndata: bye\n\n")
+	s.flusher.Flush()
+	s.closed = true
+	return nil
+}
+
+// dataToString renders data for an SSE data: line. string and []byte pass
+// through; anything else is JSON-marshaled.
+func dataToString(data any) (string, error) {
+	switch x := data.(type) {
+	case nil:
+		return "", nil
+	case string:
+		return x, nil
+	case []byte:
+		return string(x), nil
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return "", fmt.Errorf("turbo/sse: marshal data: %w", err)
+	}
+	return string(b), nil
+}
+
+// splitLines yields lines of s without trailing \n.
+func splitLines(s string) func(yield func(string) bool) {
+	return func(yield func(string) bool) {
+		start := 0
+		for i := 0; i < len(s); i++ {
+			if s[i] == '\n' {
+				if !yield(s[start:i]) {
+					return
+				}
+				start = i + 1
+			}
+		}
+		if start <= len(s) {
+			if !yield(s[start:]) {
+				return
+			}
+		}
+	}
+}

--- a/turbo/sse_test.go
+++ b/turbo/sse_test.go
@@ -1,0 +1,128 @@
+package turbo
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSSE_Headers(t *testing.T) {
+	w := httptest.NewRecorder()
+	sse, err := NewSSE(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sse.Close()
+	h := w.Header()
+	if h.Get("Content-Type") != "text/event-stream" {
+		t.Errorf("Content-Type = %q", h.Get("Content-Type"))
+	}
+	if h.Get("Cache-Control") != "no-cache" {
+		t.Errorf("Cache-Control wrong")
+	}
+	if h.Get("X-Accel-Buffering") != "no" {
+		t.Errorf("X-Accel-Buffering should be 'no' to defeat nginx buffering")
+	}
+}
+
+func TestSSE_SendStringAndJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	sse, err := NewSSE(w)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sse.Send("greet", "hello"); err != nil {
+		t.Fatalf("send string: %v", err)
+	}
+	if err := sse.Send("payload", map[string]int{"n": 42}); err != nil {
+		t.Fatalf("send map: %v", err)
+	}
+	out := w.Body.String()
+	if !strings.Contains(out, "event: greet\ndata: hello\n\n") {
+		t.Errorf("missing greet record:\n%s", out)
+	}
+	if !strings.Contains(out, "event: payload\ndata: {\"n\":42}\n\n") {
+		t.Errorf("missing payload record:\n%s", out)
+	}
+}
+
+func TestSSE_MultilineDataPrefixesEveryLine(t *testing.T) {
+	w := httptest.NewRecorder()
+	sse, _ := NewSSE(w)
+	_ = sse.Send("multi", "line1\nline2\nline3")
+	out := w.Body.String()
+	if !strings.Contains(out, "data: line1\ndata: line2\ndata: line3\n") {
+		t.Errorf("each line should be prefixed:\n%s", out)
+	}
+}
+
+func TestSSE_CloseEmitsCloseEvent(t *testing.T) {
+	w := httptest.NewRecorder()
+	sse, _ := NewSSE(w)
+	_ = sse.Close()
+	if !strings.Contains(w.Body.String(), "event: close\ndata: bye\n\n") {
+		t.Errorf("close should emit close event; got:\n%s", w.Body.String())
+	}
+	// Send after Close should error.
+	if err := sse.Send("x", "y"); err == nil {
+		t.Error("send after close should error")
+	}
+}
+
+func TestSSE_NoFlusherReturnsErr(t *testing.T) {
+	// Explicitly-non-Flusher wrapper (embedding would promote Flush() from
+	// the recorder and defeat the test).
+	rec := httptest.NewRecorder()
+	w := &nonFlusherWriter{rec: rec}
+	if _, err := NewSSE(w); err != ErrUnflushable {
+		t.Errorf("expected ErrUnflushable; got %v", err)
+	}
+}
+
+type nonFlusherWriter struct {
+	rec *httptest.ResponseRecorder
+}
+
+func (n *nonFlusherWriter) Header() http.Header         { return n.rec.Header() }
+func (n *nonFlusherWriter) Write(b []byte) (int, error) { return n.rec.Write(b) }
+func (n *nonFlusherWriter) WriteHeader(s int)           { n.rec.WriteHeader(s) }
+
+// Real end-to-end with an actual httptest.Server to prove streaming works.
+func TestSSE_EndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sse, err := NewSSE(w)
+		if err != nil {
+			t.Errorf("NewSSE: %v", err)
+			return
+		}
+		defer sse.Close()
+		for i := 0; i < 3; i++ {
+			_ = sse.Send("tick", i)
+		}
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+	for i := 0; i < 3; i++ {
+		want := "event: tick\ndata: " + string(rune('0'+i))
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in body:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "event: close") {
+		t.Errorf("missing close event:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Description
Four additive turbo features — SSE helper, JWT middleware, token-bucket rate limit, route groups — all stdlib-only and opt-in.

### Related Issue
Closes #168
Closes #169
Closes #170
Closes #171

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring
- [x] ✅ Test update
- [ ] 🔨 Build / CI changes

## Changes Made
**`turbo/sse.go`** (#168) — `NewSSE(w)` returns `*SSEWriter` with `Send(event, data)` / `Flush` / `Close`. Headers set for streaming (`X-Accel-Buffering: no`). Multi-line data is split into separate `data:` lines per RFC. JSON marshaling for struct payloads; strings/`[]byte` pass through.

**`turbo/auth/jwt.go`** (#169) — `JWT(JWTConfig{Verify: func(token string)(any,error), ...})` returns an `Authenticator`. **Decoupled** from `golly/auth` via the `VerifyFunc` callback — turbo doesn't import auth, so this PR ships standalone and consumers wire whatever verifier they like. `ClaimsFrom(ctx)` helper, custom ContextKey / Scheme / HeaderName, `OnError`/`OnMissing` overrides.

**`turbo/filters/ratelimit.go`** (#170) — `RateLimit({Rate, Burst, Principal, OnLimit, Now})` token-bucket middleware. In-process store; per-principal isolation; empty principal bypasses; `Retry-After` header on 429. `PrincipalFromHeader(name)` extractor helper.

**`turbo/group.go`** (#171) — `Router.Group(prefix) *Group` with nested groups composing prefixes; `Use(filters...)` + `AddAuthenticator(a)` inherit through children; `Get/Post/Put/Delete/Add` register against the group.

## Testing
- [x] I have added/updated unit tests
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

```
$ go test -race ./turbo/...
ok  oss.nandlabs.io/golly/turbo
ok  oss.nandlabs.io/golly/turbo/auth
ok  oss.nandlabs.io/golly/turbo/filters
# 15 new tests, 0 failures, lint clean
```

## Checklist
- [x] code follows project style
- [x] self-review done
- [x] commented non-obvious code
- [x] docs updated
- [x] no new warnings
- [x] read CONTRIBUTING
- [x] dual-license consent

## Additional Context
**Zero new external deps** — stdlib only (`net/http`, `encoding/json`, `sync`, `time`, `strings`, `strconv`).

**Backward compatible** — every addition is opt-in: existing `Router`/`Route`/`AddFilter`/`AddCorsFilter` callers see no change. Existing `turbo/auth` package is extended (JWT is a new type alongside the existing `Authenticator` interface), `turbo/filters` gains a new file (CORS untouched).

**Pairs with #172 (`auth`)** — the JWT middleware's `VerifyFunc` is intentionally library-agnostic; the typical wiring is `cfg.Verify = func(t string) (any, error) { return auth.Verify(t, auth.VerifyOptions{...}) }`.
