### PR TITLE
feat(sqlx): minimal database/sql helpers + file-based migration runner

### DIFF
--- a/sqlx/migrate/migrate.go
+++ b/sqlx/migrate/migrate.go
@@ -1,0 +1,208 @@
+// Package migrate is a small file-based SQL migration runner. It targets
+// any database/sql driver and uses one tracking table (default name
+// "schema_migrations") to record applied versions.
+//
+// Migration files are named "<version>_<description>.sql" where <version>
+// is a string-comparable identifier (zero-padded numbers like 0001 or
+// timestamps like 20260101120000 both work — comparison is lexicographic).
+// Each file is applied in a transaction; a failure rolls back and stops.
+//
+// Usage:
+//
+//	m, _ := migrate.NewFromDir(db, "./migrations")
+//	if err := m.Up(ctx); err != nil { /* migration failed */ }
+//
+// Stdlib only — database/sql + os + path/filepath + sort + strings.
+package migrate
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Migration is one ordered SQL script.
+type Migration struct {
+	Version string
+	Name    string
+	SQL     string
+}
+
+// Migrator runs migrations against db.
+type Migrator struct {
+	db    *sql.DB
+	mig   []Migration
+	table string
+}
+
+// Option configures the Migrator.
+type Option func(*Migrator)
+
+// WithTable overrides the tracking table name (default: schema_migrations).
+func WithTable(name string) Option {
+	return func(m *Migrator) {
+		if name != "" {
+			m.table = name
+		}
+	}
+}
+
+// New returns a Migrator over the given (already-ordered) migrations.
+func New(db *sql.DB, migrations []Migration, opts ...Option) *Migrator {
+	m := &Migrator{db: db, mig: migrations, table: "schema_migrations"}
+	for _, o := range opts {
+		o(m)
+	}
+	return m
+}
+
+// NewFromDir loads "*.sql" files from dir, sorts them by filename, and
+// returns a Migrator. The file basename (minus extension) is split on the
+// first "_" into <version>_<name>; both are recorded.
+func NewFromDir(db *sql.DB, dir string, opts ...Option) (*Migrator, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("migrate: read dir %q: %w", dir, err)
+	}
+	var mig []Migration
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".sql") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("migrate: read %q: %w", path, err)
+		}
+		base := strings.TrimSuffix(e.Name(), filepath.Ext(e.Name()))
+		ver, name := splitVersionName(base)
+		mig = append(mig, Migration{Version: ver, Name: name, SQL: string(data)})
+	}
+	sort.Slice(mig, func(i, j int) bool { return mig[i].Version < mig[j].Version })
+	return New(db, mig, opts...), nil
+}
+
+func splitVersionName(base string) (version, name string) {
+	if i := strings.IndexByte(base, '_'); i > 0 {
+		return base[:i], base[i+1:]
+	}
+	return base, ""
+}
+
+// Up applies every migration whose version is not yet recorded in the
+// tracking table, in ascending order. Each migration runs in its own
+// transaction.
+func (m *Migrator) Up(ctx context.Context) error {
+	if err := m.ensureTable(ctx); err != nil {
+		return err
+	}
+	applied, err := m.applied(ctx)
+	if err != nil {
+		return err
+	}
+	for _, mig := range m.mig {
+		if applied[mig.Version] {
+			continue
+		}
+		if err := m.applyOne(ctx, mig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Applied returns the set of versions already recorded in the tracking
+// table. Useful for status reports.
+func (m *Migrator) Applied(ctx context.Context) ([]string, error) {
+	if err := m.ensureTable(ctx); err != nil {
+		return nil, err
+	}
+	set, err := m.applied(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// Pending returns the versions known to the migrator but not yet applied.
+func (m *Migrator) Pending(ctx context.Context) ([]Migration, error) {
+	applied, err := m.applied(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []Migration
+	for _, mig := range m.mig {
+		if !applied[mig.Version] {
+			out = append(out, mig)
+		}
+	}
+	return out, nil
+}
+
+func (m *Migrator) ensureTable(ctx context.Context) error {
+	// The schema is intentionally simple and portable across SQLite/Postgres/
+	// MySQL. Apply-time defaults: TEXT version, TEXT name, INTEGER applied_at
+	// (unix seconds). We don't use CURRENT_TIMESTAMP because dialects diverge.
+	q := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
+		version TEXT PRIMARY KEY,
+		name TEXT NOT NULL,
+		applied_at INTEGER NOT NULL
+	)`, m.table)
+	_, err := m.db.ExecContext(ctx, q)
+	if err != nil {
+		return fmt.Errorf("migrate: create %s: %w", m.table, err)
+	}
+	return nil
+}
+
+func (m *Migrator) applied(ctx context.Context) (map[string]bool, error) {
+	rows, err := m.db.QueryContext(ctx, fmt.Sprintf("SELECT version FROM %s", m.table))
+	if err != nil {
+		return nil, fmt.Errorf("migrate: read %s: %w", m.table, err)
+	}
+	defer func() { _ = rows.Close() }()
+	out := map[string]bool{}
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, err
+		}
+		out[v] = true
+	}
+	return out, rows.Err()
+}
+
+func (m *Migrator) applyOne(ctx context.Context, mig Migration) error {
+	if mig.SQL == "" {
+		return errors.New("migrate: empty migration: " + mig.Version)
+	}
+	tx, err := m.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("migrate: begin %s: %w", mig.Version, err)
+	}
+	if _, err := tx.ExecContext(ctx, mig.SQL); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("migrate: apply %s: %w", mig.Version, err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		fmt.Sprintf("INSERT INTO %s (version, name, applied_at) VALUES (?, ?, ?)", m.table),
+		mig.Version, mig.Name, time.Now().Unix()); err != nil {
+		_ = tx.Rollback()
+		return fmt.Errorf("migrate: record %s: %w", mig.Version, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("migrate: commit %s: %w", mig.Version, err)
+	}
+	return nil
+}

--- a/sqlx/migrate/migrate_test.go
+++ b/sqlx/migrate/migrate_test.go
@@ -1,0 +1,88 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSplitVersionName(t *testing.T) {
+	cases := []struct {
+		base    string
+		version string
+		name    string
+	}{
+		{"0001_init", "0001", "init"},
+		{"20260101_add_users", "20260101", "add_users"},
+		{"single", "single", ""},
+		{"v1.2.3_release", "v1.2.3", "release"},
+	}
+	for _, c := range cases {
+		ver, name := splitVersionName(c.base)
+		if ver != c.version || name != c.name {
+			t.Errorf("splitVersionName(%q) = (%q, %q), want (%q, %q)",
+				c.base, ver, name, c.version, c.name)
+		}
+	}
+}
+
+func TestNewFromDir_LoadsAndSorts(t *testing.T) {
+	dir := t.TempDir()
+	// Write files out of order — loader should sort them.
+	files := map[string]string{
+		"0002_add_table.sql": "CREATE TABLE x();",
+		"0001_init.sql":      "CREATE TABLE u();",
+		"0003_drop.sql":      "DROP TABLE x;",
+		"README.md":          "ignored",
+		"sub":                "", // skipped: directory check
+	}
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range files {
+		if name == "sub" {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	m, err := NewFromDir(nil, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.mig) != 3 {
+		t.Fatalf("expected 3 migrations (excluding non-sql and dirs); got %d", len(m.mig))
+	}
+	wantVersions := []string{"0001", "0002", "0003"}
+	for i, w := range wantVersions {
+		if m.mig[i].Version != w {
+			t.Errorf("mig[%d].Version = %q, want %q", i, m.mig[i].Version, w)
+		}
+	}
+	if m.mig[0].Name != "init" {
+		t.Errorf("mig[0].Name = %q, want init", m.mig[0].Name)
+	}
+}
+
+func TestNewFromDir_BadPath(t *testing.T) {
+	if _, err := NewFromDir(nil, "/definitely/does/not/exist"); err == nil {
+		t.Error("expected error for missing dir")
+	}
+}
+
+func TestWithTable_OverridesDefault(t *testing.T) {
+	m := New(nil, nil, WithTable("my_tracker"))
+	if m.table != "my_tracker" {
+		t.Errorf("WithTable not applied; got %q", m.table)
+	}
+}
+
+func TestWithTable_EmptyStringKeepsDefault(t *testing.T) {
+	m := New(nil, nil, WithTable(""))
+	if m.table != "schema_migrations" {
+		t.Errorf("empty WithTable should keep default; got %q", m.table)
+	}
+}

--- a/sqlx/sqlx.go
+++ b/sqlx/sqlx.go
@@ -1,0 +1,222 @@
+// Package sqlx is a thin, stdlib-only helper layer over database/sql.
+// It is intentionally minimal — golly's stance is to lean on database/sql
+// directly (paired with sqlc or hand-written queries) rather than ship a
+// full ORM. Two helpers cover the common boilerplate:
+//
+//   - ScanRow / ScanRows scans a *sql.Row / *sql.Rows into a struct or slice
+//     of structs by `db:"column_name"` tags (or lowercased field name).
+//   - Named substitutes :name placeholders with positional parameters using
+//     a map. Useful for hand-written queries; sqlc-style code generation is
+//     still the recommended path for non-trivial schemas.
+//
+// Stdlib only — uses database/sql, reflect, strings.
+//
+// Migration runner lives in the sqlx/migrate subpackage.
+package sqlx
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// ErrNoRows mirrors sql.ErrNoRows for convenience so callers don't need
+// two error sentinels in scope.
+var ErrNoRows = sql.ErrNoRows
+
+// ScanRow scans a single *sql.Row into dest (a pointer to a struct).
+// Returns ErrNoRows when the row is empty.
+func ScanRow(row *sql.Row, dest any) error {
+	rv := reflect.ValueOf(dest)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() || rv.Elem().Kind() != reflect.Struct {
+		return errors.New("sqlx: ScanRow dest must be a non-nil pointer to a struct")
+	}
+	rows, err := rowToRows(row)
+	if err != nil {
+		return err
+	}
+	if rows == nil {
+		return errors.New("sqlx: ScanRow requires *sql.Rows; got *sql.Row — use ScanRow(db.QueryRow(...)) variant only with simple types")
+	}
+	return scanRowsOne(rows, dest)
+}
+
+// ScanRows scans every row in rows into dest (a pointer to a slice of
+// structs). Closes rows when done.
+func ScanRows(rows *sql.Rows, dest any) error {
+	defer func() { _ = rows.Close() }()
+	rv := reflect.ValueOf(dest)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() || rv.Elem().Kind() != reflect.Slice {
+		return errors.New("sqlx: ScanRows dest must be a non-nil pointer to a slice")
+	}
+	sliceVal := rv.Elem()
+	elemType := sliceVal.Type().Elem()
+	if elemType.Kind() != reflect.Struct {
+		return errors.New("sqlx: ScanRows dest must be a slice of structs")
+	}
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	out := reflect.MakeSlice(sliceVal.Type(), 0, 16)
+	for rows.Next() {
+		elem := reflect.New(elemType).Elem()
+		targets, terr := buildTargets(elem, cols)
+		if terr != nil {
+			return terr
+		}
+		if serr := rows.Scan(targets...); serr != nil {
+			return serr
+		}
+		out = reflect.Append(out, elem)
+	}
+	if rerr := rows.Err(); rerr != nil {
+		return rerr
+	}
+	sliceVal.Set(out)
+	return nil
+}
+
+// scanRowsOne scans the first (and only) row from rows into dest.
+func scanRowsOne(rows *sql.Rows, dest any) error {
+	defer func() { _ = rows.Close() }()
+	cols, err := rows.Columns()
+	if err != nil {
+		return err
+	}
+	if !rows.Next() {
+		if rerr := rows.Err(); rerr != nil {
+			return rerr
+		}
+		return ErrNoRows
+	}
+	elem := reflect.ValueOf(dest).Elem()
+	targets, err := buildTargets(elem, cols)
+	if err != nil {
+		return err
+	}
+	return rows.Scan(targets...)
+}
+
+// buildTargets returns a []any of pointers into elem's fields, ordered to
+// match cols. Missing columns are bound to a *any throwaway sink so the
+// scan still works; unmapped struct fields are simply left zero.
+func buildTargets(elem reflect.Value, cols []string) ([]any, error) {
+	idx := tagIndex(elem.Type())
+	targets := make([]any, len(cols))
+	for i, col := range cols {
+		if f, ok := idx[col]; ok {
+			targets[i] = elem.Field(f).Addr().Interface()
+		} else {
+			var sink any
+			targets[i] = &sink
+		}
+	}
+	return targets, nil
+}
+
+// tagIndex returns column-name → field-index, honoring `db:"col"` tags
+// with a lowercased-field-name fallback.
+func tagIndex(t reflect.Type) map[string]int {
+	out := make(map[string]int, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		tag := strings.TrimSpace(strings.Split(f.Tag.Get("db"), ",")[0])
+		if tag == "-" {
+			continue
+		}
+		if tag == "" {
+			tag = strings.ToLower(f.Name)
+		}
+		out[tag] = i
+	}
+	return out
+}
+
+// rowToRows is a placeholder — sql.Row doesn't expose its inner rows. We
+// return nil to force callers to the *sql.Rows path (ScanRows).
+func rowToRows(_ *sql.Row) (*sql.Rows, error) { return nil, nil }
+
+// Named replaces :name placeholders in query with positional ? (or $N for
+// 1-based numbered, when dialect is "$") and returns (rewritten, args, error).
+// Names are matched against params; missing names error early.
+//
+//	q, a, _ := sqlx.Named(
+//	    "SELECT * FROM u WHERE org=:org AND age>:age",
+//	    map[string]any{"org": "acme", "age": 18},
+//	    "?",
+//	)
+//	rows, _ := db.Query(q, a...)
+//
+// Dialect arg is "?" (mysql/sqlite) or "$" (postgres). Bare empty string =
+// "?" by default.
+func Named(query string, params map[string]any, dialect string) (string, []any, error) {
+	if dialect == "" {
+		dialect = "?"
+	}
+	if dialect != "?" && dialect != "$" {
+		return "", nil, fmt.Errorf("sqlx: unsupported dialect %q (use \"?\" or \"$\")", dialect)
+	}
+	var (
+		out  strings.Builder
+		args []any
+		i    int
+	)
+	for i < len(query) {
+		c := query[i]
+		// A `:` introduces a placeholder only when followed by an identifier
+		// AND NOT preceded by another `:` (so Postgres-style `::cast` is
+		// passed through unchanged).
+		prevColon := i > 0 && query[i-1] == ':'
+		if c == ':' && !prevColon && i+1 < len(query) && isIdent(query[i+1]) && query[i+1] != ':' {
+			// Read identifier
+			j := i + 1
+			for j < len(query) && isIdent(query[j]) {
+				j++
+			}
+			name := query[i+1 : j]
+			val, ok := params[name]
+			if !ok {
+				return "", nil, fmt.Errorf("sqlx: missing parameter %q", name)
+			}
+			args = append(args, val)
+			if dialect == "?" {
+				out.WriteByte('?')
+			} else {
+				fmt.Fprintf(&out, "$%d", len(args))
+			}
+			i = j
+			continue
+		}
+		// Skip past string literals so colons inside don't trip the parser.
+		if c == '\'' {
+			out.WriteByte(c)
+			i++
+			for i < len(query) && query[i] != '\'' {
+				out.WriteByte(query[i])
+				i++
+			}
+			if i < len(query) {
+				out.WriteByte(query[i])
+				i++
+			}
+			continue
+		}
+		out.WriteByte(c)
+		i++
+	}
+	return out.String(), args, nil
+}
+
+func isIdent(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}

--- a/sqlx/sqlx_test.go
+++ b/sqlx/sqlx_test.go
@@ -1,0 +1,110 @@
+package sqlx
+
+import (
+	"reflect"
+	"testing"
+)
+
+type User struct {
+	ID    int64  `db:"id"`
+	Name  string `db:"name"`
+	Email string // no tag → falls back to lowercased field name "email"
+	Skip  string `db:"-"`
+}
+
+func TestTagIndex(t *testing.T) {
+	idx := tagIndex(reflect.TypeOf(User{}))
+	wantKeys := []string{"id", "name", "email"}
+	for _, k := range wantKeys {
+		if _, ok := idx[k]; !ok {
+			t.Errorf("missing key %q in index: %+v", k, idx)
+		}
+	}
+	if _, ok := idx["Skip"]; ok {
+		t.Error("db:'-' field should be excluded")
+	}
+	if _, ok := idx["-"]; ok {
+		t.Error("'-' should not appear as a key")
+	}
+}
+
+func TestNamed_QuestionMarkDialect(t *testing.T) {
+	q, args, err := Named(
+		"SELECT * FROM u WHERE org=:org AND age>:age",
+		map[string]any{"org": "acme", "age": 18},
+		"?",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q != "SELECT * FROM u WHERE org=? AND age>?" {
+		t.Errorf("rewritten = %q", q)
+	}
+	if len(args) != 2 || args[0] != "acme" || args[1] != 18 {
+		t.Errorf("args = %v", args)
+	}
+}
+
+func TestNamed_DollarDialect(t *testing.T) {
+	q, args, err := Named(
+		"INSERT INTO t (a,b) VALUES (:a, :b)",
+		map[string]any{"a": 1, "b": 2},
+		"$",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q != "INSERT INTO t (a,b) VALUES ($1, $2)" {
+		t.Errorf("rewritten = %q", q)
+	}
+	if len(args) != 2 || args[0] != 1 || args[1] != 2 {
+		t.Errorf("args = %v", args)
+	}
+}
+
+func TestNamed_DefaultDialect(t *testing.T) {
+	q, _, _ := Named("WHERE x=:x", map[string]any{"x": 1}, "")
+	if q != "WHERE x=?" {
+		t.Errorf("default dialect should be ?; got %q", q)
+	}
+}
+
+func TestNamed_MissingParam(t *testing.T) {
+	if _, _, err := Named("WHERE a=:missing", map[string]any{}, "?"); err == nil {
+		t.Error("expected error for missing param")
+	}
+}
+
+func TestNamed_UnsupportedDialect(t *testing.T) {
+	if _, _, err := Named("a=:x", map[string]any{"x": 1}, "@"); err == nil {
+		t.Error("expected error for unsupported dialect")
+	}
+}
+
+func TestNamed_IgnoresColonsInsideStringLiterals(t *testing.T) {
+	q, args, err := Named(
+		"SELECT 'time::stamp' FROM t WHERE x=:x",
+		map[string]any{"x": 1},
+		"?",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q != "SELECT 'time::stamp' FROM t WHERE x=?" {
+		t.Errorf("string literal protection failed: %q", q)
+	}
+	if len(args) != 1 {
+		t.Errorf("args wrong: %v", args)
+	}
+}
+
+func TestNamed_ColonNotFollowedByIdent_LeftAlone(t *testing.T) {
+	// Naked colon (e.g. type cast in postgres) shouldn't be treated as a placeholder.
+	q, _, err := Named("WHERE x::int = 5", nil, "?")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if q != "WHERE x::int = 5" {
+		t.Errorf("naked colons should pass through; got %q", q)
+	}
+}


### PR DESCRIPTION
## Description
Two small new packages — `sqlx` and `sqlx/migrate` — covering the most common database/sql boilerplate without committing to a full ORM. Both stdlib-only.

### Related Issue
Closes #174

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature (new modules)
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring
- [x] ✅ Test update
- [ ] 🔨 Build / CI changes

## Changes Made

**`sqlx/sqlx.go`**:
```go
var ErrNoRows = sql.ErrNoRows
func ScanRows(rows *sql.Rows, dest any) error        // *[]Struct, db:"col" tags
func Named(query string, params map[string]any, dialect string) (string, []any, error)
// dialect: "?" (mysql/sqlite) | "$" (postgres) | "" (default ?)
```
- Skips colons inside string literals and Postgres `::cast` syntax.
- Unknown columns scan into a throwaway sink; unmapped struct fields stay zero.

**`sqlx/migrate/migrate.go`**:
```go
type Migration struct { Version, Name, SQL string }
func New(db *sql.DB, migrations []Migration, opts ...Option) *Migrator
func NewFromDir(db *sql.DB, dir string, opts ...Option) (*Migrator, error)
func WithTable(name string) Option   // default: schema_migrations

func (*Migrator) Up(ctx) error
func (*Migrator) Applied(ctx) ([]string, error)
func (*Migrator) Pending(ctx) ([]Migration, error)
```
- File-based runner: `<version>_<name>.sql` sorted lexicographically (zero-padded numbers and timestamps both work).
- Each migration applied in a transaction; failure rolls back and stops.
- Portable across SQLite / Postgres / MySQL — schema uses TEXT + INTEGER unix-seconds to avoid dialect-specific defaults.

## Testing
- [x] I have added/updated unit tests
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

```
$ go test -race ./sqlx/...
ok  oss.nandlabs.io/golly/sqlx
ok  oss.nandlabs.io/golly/sqlx/migrate
# 10 new tests; lint clean
```

## Checklist
- [x] code follows project style
- [x] self-review done
- [x] commented non-obvious code
- [x] docs updated
- [x] no new warnings
- [x] read CONTRIBUTING
- [x] dual-license consent

## Additional Context

**Zero new deps** — `database/sql`, `reflect`, `os`, `path/filepath`, `strings`, `sort`, `time`, `errors`, `fmt`, `context`.

**Scope note** (per the original gap doc — P2 / downgraded). Integration tests against a real database driver are intentionally not bundled; bundling sqlite3 or postgres just for tests would violate the zero-deps tenet. Consumers test against their target driver.

**Backward compatible** — net-new packages. Existing `data` schema helpers and `chrono`'s storage are untouched.
