### PR TITLE
feat(messaging): broker-targeted options (delivery / DLQ / consumer mode / ack)

### DIFF
--- a/messaging/broker_options.go
+++ b/messaging/broker_options.go
@@ -1,0 +1,105 @@
+package messaging
+
+import "time"
+
+// Broker-targeted option keys. These are recognized by durable / brokered
+// Providers (JetStream, Kafka, RabbitMQ, …) that ship as satellite modules.
+// The in-tree LocalProvider ignores them — they're advisory hints, not
+// hard requirements for the Provider interface.
+const (
+	// DeliveryGuaranteeOpt selects the broker's delivery semantics.
+	// Value: DeliveryGuarantee (AtMostOnce / AtLeastOnce / ExactlyOnce).
+	DeliveryGuaranteeOpt = "DeliveryGuarantee"
+
+	// DeadLetterOpt names a destination topic/queue/stream that receives
+	// messages whose primary delivery exhausts retries or violates schema.
+	// Value: string (broker-specific identifier).
+	DeadLetterOpt = "DeadLetter"
+
+	// MaxDeliveryAttemptsOpt caps how many times a broker will redeliver a
+	// message before routing it to the DeadLetter destination (when set).
+	// Value: int (> 0). Brokers without redelivery semantics ignore it.
+	MaxDeliveryAttemptsOpt = "MaxDeliveryAttempts"
+
+	// ConsumerModeOpt selects between long-poll/push or pull-based consumption.
+	// Value: ConsumerMode (ConsumerPush / ConsumerPull).
+	ConsumerModeOpt = "ConsumerMode"
+
+	// AckTimeoutOpt is the per-message acknowledgment deadline; messages
+	// not ack'd within this window are redelivered (subject to
+	// MaxDeliveryAttempts). Value: time.Duration.
+	AckTimeoutOpt = "AckTimeout"
+)
+
+// DeliveryGuarantee is the broker-side delivery semantic for produced messages.
+type DeliveryGuarantee string
+
+const (
+	// AtMostOnce is the cheapest mode — messages may be lost on broker
+	// failure, but never duplicated. Suitable for metrics, telemetry, etc.
+	AtMostOnce DeliveryGuarantee = "at-most-once"
+
+	// AtLeastOnce is the default for most durable brokers — messages are
+	// never lost but may be redelivered on broker / consumer failure.
+	// Pair with idempotent consumers.
+	AtLeastOnce DeliveryGuarantee = "at-least-once"
+
+	// ExactlyOnce requires broker-side dedup + transactional consumers
+	// (e.g. JetStream exactly-once, Kafka EOS). Strongest guarantee,
+	// highest overhead.
+	ExactlyOnce DeliveryGuarantee = "exactly-once"
+)
+
+// ConsumerMode selects between server-pushed delivery and consumer-pulled fetch.
+type ConsumerMode string
+
+const (
+	// ConsumerPush is the default for most brokers — the server streams
+	// messages as they arrive; the consumer's handler is invoked per message.
+	ConsumerPush ConsumerMode = "push"
+
+	// ConsumerPull asks the consumer to explicitly fetch batches at its
+	// own pace. Useful for back-pressure control on slow consumers.
+	ConsumerPull ConsumerMode = "pull"
+)
+
+// --- OptionsBuilder additions ---
+
+// AddDeliveryGuarantee sets the broker's delivery semantics for produced
+// messages. Brokers without the requested mode (e.g. AtMostOnce on a strict
+// JetStream stream) should return an error from Provider.NewProducer.
+func (ob *OptionsBuilder) AddDeliveryGuarantee(g DeliveryGuarantee) *OptionsBuilder {
+	return ob.Add(DeliveryGuaranteeOpt, g)
+}
+
+// AddDeadLetter routes messages that exhaust retries (or violate schema) to
+// destination. The destination format is broker-specific (a subject in NATS,
+// a topic in Kafka, etc.). Pair with AddMaxDeliveryAttempts for an explicit
+// redelivery cap.
+func (ob *OptionsBuilder) AddDeadLetter(destination string) *OptionsBuilder {
+	return ob.Add(DeadLetterOpt, destination)
+}
+
+// AddMaxDeliveryAttempts caps redelivery attempts before routing to the
+// DeadLetter destination (when configured). n must be > 0.
+func (ob *OptionsBuilder) AddMaxDeliveryAttempts(n int) *OptionsBuilder {
+	if n <= 0 {
+		return ob
+	}
+	return ob.Add(MaxDeliveryAttemptsOpt, n)
+}
+
+// AddConsumerMode selects push vs pull delivery on consumers that support
+// both (most JetStream / Kafka consumers).
+func (ob *OptionsBuilder) AddConsumerMode(m ConsumerMode) *OptionsBuilder {
+	return ob.Add(ConsumerModeOpt, m)
+}
+
+// AddAckTimeout sets the per-message acknowledgment window. Messages not
+// ack'd within d are redelivered (subject to MaxDeliveryAttempts).
+func (ob *OptionsBuilder) AddAckTimeout(d time.Duration) *OptionsBuilder {
+	if d <= 0 {
+		return ob
+	}
+	return ob.Add(AckTimeoutOpt, d)
+}

--- a/messaging/broker_options_test.go
+++ b/messaging/broker_options_test.go
@@ -1,0 +1,83 @@
+package messaging
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAddDeliveryGuarantee(t *testing.T) {
+	opts := NewOptionsBuilder().AddDeliveryGuarantee(AtLeastOnce).Build()
+	got, ok := GetOptValue[DeliveryGuarantee](DeliveryGuaranteeOpt, opts...)
+	if !ok || got != AtLeastOnce {
+		t.Errorf("DeliveryGuarantee roundtrip wrong: ok=%v val=%v", ok, got)
+	}
+}
+
+func TestAddDeadLetter(t *testing.T) {
+	opts := NewOptionsBuilder().AddDeadLetter("dlq.events").Build()
+	got, ok := GetOptValue[string](DeadLetterOpt, opts...)
+	if !ok || got != "dlq.events" {
+		t.Errorf("DeadLetter roundtrip wrong: ok=%v val=%q", ok, got)
+	}
+}
+
+func TestAddMaxDeliveryAttempts(t *testing.T) {
+	opts := NewOptionsBuilder().AddMaxDeliveryAttempts(5).Build()
+	got, ok := GetOptValue[int](MaxDeliveryAttemptsOpt, opts...)
+	if !ok || got != 5 {
+		t.Errorf("MaxDeliveryAttempts roundtrip wrong: ok=%v val=%d", ok, got)
+	}
+}
+
+func TestAddMaxDeliveryAttempts_ZeroIsNoop(t *testing.T) {
+	opts := NewOptionsBuilder().AddMaxDeliveryAttempts(0).Build()
+	if _, ok := GetOptValue[int](MaxDeliveryAttemptsOpt, opts...); ok {
+		t.Errorf("zero MaxDeliveryAttempts should not be recorded")
+	}
+}
+
+func TestAddConsumerMode(t *testing.T) {
+	cases := []ConsumerMode{ConsumerPush, ConsumerPull}
+	for _, m := range cases {
+		opts := NewOptionsBuilder().AddConsumerMode(m).Build()
+		got, ok := GetOptValue[ConsumerMode](ConsumerModeOpt, opts...)
+		if !ok || got != m {
+			t.Errorf("ConsumerMode(%v) roundtrip wrong: ok=%v val=%v", m, ok, got)
+		}
+	}
+}
+
+func TestAddAckTimeout(t *testing.T) {
+	opts := NewOptionsBuilder().AddAckTimeout(30 * time.Second).Build()
+	got, ok := GetOptValue[time.Duration](AckTimeoutOpt, opts...)
+	if !ok || got != 30*time.Second {
+		t.Errorf("AckTimeout roundtrip wrong: ok=%v val=%v", ok, got)
+	}
+}
+
+func TestAddAckTimeout_ZeroIsNoop(t *testing.T) {
+	opts := NewOptionsBuilder().AddAckTimeout(0).Build()
+	if _, ok := GetOptValue[time.Duration](AckTimeoutOpt, opts...); ok {
+		t.Errorf("zero AckTimeout should not be recorded")
+	}
+}
+
+func TestBrokerOptions_CompositeBuild(t *testing.T) {
+	opts := NewOptionsBuilder().
+		AddDeliveryGuarantee(ExactlyOnce).
+		AddDeadLetter("dlq").
+		AddMaxDeliveryAttempts(3).
+		AddConsumerMode(ConsumerPull).
+		AddAckTimeout(10 * time.Second).
+		Build()
+
+	if len(opts) != 5 {
+		t.Fatalf("expected 5 options recorded; got %d", len(opts))
+	}
+	if g, _ := GetOptValue[DeliveryGuarantee](DeliveryGuaranteeOpt, opts...); g != ExactlyOnce {
+		t.Errorf("DeliveryGuarantee wrong: %v", g)
+	}
+	if d, _ := GetOptValue[string](DeadLetterOpt, opts...); d != "dlq" {
+		t.Errorf("DeadLetter wrong: %q", d)
+	}
+}


### PR DESCRIPTION
## Description
Adds the cross-broker option keys + builder methods called out by the gap doc — delivery guarantees, dead-letter routing, max-delivery-attempts cap, consumer push/pull mode, and ack timeout. Used by satellite-module brokers (NATS JetStream, Kafka, RabbitMQ) without bringing their SDK dependencies into core.

### Related Issue
Closes #179

## Type of Change
- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking)
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring
- [x] ✅ Test update
- [ ] 🔨 Build / CI changes

## Changes Made

**`messaging/broker_options.go`** (new):
```go
// Keys
DeliveryGuaranteeOpt    // DeliveryGuarantee: AtMostOnce / AtLeastOnce / ExactlyOnce
DeadLetterOpt           // string destination
MaxDeliveryAttemptsOpt  // int (>0)
ConsumerModeOpt         // ConsumerMode: ConsumerPush / ConsumerPull
AckTimeoutOpt           // time.Duration

// Builder methods
(*OptionsBuilder).AddDeliveryGuarantee(g DeliveryGuarantee)
(*OptionsBuilder).AddDeadLetter(destination string)
(*OptionsBuilder).AddMaxDeliveryAttempts(n int)       // no-op for ≤0
(*OptionsBuilder).AddConsumerMode(m ConsumerMode)
(*OptionsBuilder).AddAckTimeout(d time.Duration)      // no-op for ≤0
```

## Testing
- [x] I have added/updated unit tests
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

```
$ go test -race ./messaging/...
ok  oss.nandlabs.io/golly/messaging  1.9s
# 8 new tests; lint clean
```

## Checklist
- [x] code follows project style
- [x] self-review done
- [x] commented non-obvious code
- [x] docs updated
- [x] no new warnings
- [x] read CONTRIBUTING
- [x] dual-license consent

## Additional Context

**Zero new deps** — `time` only.

**Backward compatible** — net-additive. The in-tree `LocalProvider` ignores these (they're advisory hints, not interface contract changes). Existing `Provider` / `Producer` / `Receiver` interfaces are unchanged.

**Pairs with future broker satellites.** A future `messaging/jetstream` (or similar) module that wires NATS JetStream / Kafka can keep its driver dep isolated and read these keys via the existing `GetOptValue` / `OptionsResolver` helpers. The original gap doc explicitly noted that shipping a broker provider in-tree would violate the zero-deps tenet; the satellite-module pattern keeps both clean.
