### PR TITLE
feat(messaging): ListenerRemover capability (closes #94)

### DIFF
--- a/messaging/local_provider.go
+++ b/messaging/local_provider.go
@@ -177,6 +177,37 @@ func (lp *LocalProvider) AddListener(url *url.URL, listener func(msg Message), o
 	return nil
 }
 
+// RemoveListeners drops every listener registered for the URL. The
+// underlying destination channel and dispatch goroutine remain alive
+// (subsequent Send/Receive calls continue to work, and new AddListener
+// calls re-attach immediately). Idempotent — returns nil even if no
+// listeners were registered.
+func (lp *LocalProvider) RemoveListeners(url *url.URL) error {
+	lp.mutex.Lock()
+	defer lp.mutex.Unlock()
+	if lp.closed {
+		return ErrProviderClosed
+	}
+	delete(lp.listeners, url.Host)
+	return nil
+}
+
+// RemoveNamedListener drops the listeners registered under the given
+// named group for the URL. Other listener groups (including unnamed)
+// on the same URL are untouched. Idempotent — returns nil if the URL
+// or name is unknown.
+func (lp *LocalProvider) RemoveNamedListener(url *url.URL, name string) error {
+	lp.mutex.Lock()
+	defer lp.mutex.Unlock()
+	if lp.closed {
+		return ErrProviderClosed
+	}
+	if groups, ok := lp.listeners[url.Host]; ok {
+		delete(groups, name)
+	}
+	return nil
+}
+
 // dispatchMessages reads messages from the channel and dispatches them to
 // registered listeners. Takes a snapshot of listeners under read lock to
 // avoid data races with concurrent AddListener calls.

--- a/messaging/local_provider_test.go
+++ b/messaging/local_provider_test.go
@@ -426,3 +426,145 @@ func TestLocalProvider_ManagerAddListener(t *testing.T) {
 		t.Fatal("listener did not receive message within timeout")
 	}
 }
+
+// --- Listener removal (ListenerRemover) ---
+
+func TestLocalProvider_RemoveListeners_DropsAll(t *testing.T) {
+	lp := newTestProvider(t)
+	uri := mustParseURL(t, "chan://remove-all")
+
+	var fired atomic.Int32
+	err := lp.AddListener(uri, func(Message) { fired.Add(1) })
+	assert.NoError(t, err)
+	err = lp.AddListener(uri, func(Message) { fired.Add(1) })
+	assert.NoError(t, err)
+
+	// Remove all listeners; subsequent messages must not fire any.
+	err = lp.RemoveListeners(uri)
+	assert.NoError(t, err)
+
+	msg, err := NewLocalMessage()
+	assert.NoError(t, err)
+	_, _ = msg.SetBodyStr("ignored")
+	err = lp.Send(uri, msg)
+	assert.NoError(t, err)
+
+	// Give the dispatch goroutine time to (not) fire anything.
+	time.Sleep(150 * time.Millisecond)
+	if fired.Load() != 0 {
+		t.Fatalf("expected 0 listener fires after RemoveListeners, got %d", fired.Load())
+	}
+}
+
+func TestLocalProvider_RemoveListeners_Idempotent(t *testing.T) {
+	lp := newTestProvider(t)
+	uri := mustParseURL(t, "chan://remove-idempotent")
+
+	// Remove with no listeners registered yet.
+	assert.NoError(t, lp.RemoveListeners(uri))
+	// Remove twice.
+	assert.NoError(t, lp.RemoveListeners(uri))
+
+	// Add a listener, remove, remove again.
+	assert.NoError(t, lp.AddListener(uri, func(Message) {}))
+	assert.NoError(t, lp.RemoveListeners(uri))
+	assert.NoError(t, lp.RemoveListeners(uri))
+}
+
+func TestLocalProvider_RemoveNamedListener_LeavesOthers(t *testing.T) {
+	lp := newTestProvider(t)
+	uri := mustParseURL(t, "chan://remove-named")
+
+	var unnamedFired atomic.Int32
+	var keptNamedFired atomic.Int32
+	var droppedNamedFired atomic.Int32
+
+	assert.NoError(t, lp.AddListener(uri, func(Message) { unnamedFired.Add(1) }))
+	assert.NoError(t, lp.AddListener(uri, func(Message) { keptNamedFired.Add(1) },
+		NewOptionsBuilder().AddNamedListener("keep").Build()...))
+	assert.NoError(t, lp.AddListener(uri, func(Message) { droppedNamedFired.Add(1) },
+		NewOptionsBuilder().AddNamedListener("drop").Build()...))
+
+	// Remove only the "drop" named group.
+	assert.NoError(t, lp.RemoveNamedListener(uri, "drop"))
+
+	msg, _ := NewLocalMessage()
+	_, _ = msg.SetBodyStr("partial")
+	assert.NoError(t, lp.Send(uri, msg))
+
+	// Wait for dispatch.
+	time.Sleep(150 * time.Millisecond)
+
+	if unnamedFired.Load() != 1 {
+		t.Errorf("unnamed listener should have fired once; got %d", unnamedFired.Load())
+	}
+	if keptNamedFired.Load() != 1 {
+		t.Errorf("kept named listener should have fired once; got %d", keptNamedFired.Load())
+	}
+	if droppedNamedFired.Load() != 0 {
+		t.Errorf("dropped named listener should NOT have fired; got %d", droppedNamedFired.Load())
+	}
+}
+
+func TestLocalProvider_RemoveListeners_ClosedProvider(t *testing.T) {
+	lp := &LocalProvider{}
+	assert.NoError(t, lp.Setup())
+	assert.NoError(t, lp.Close())
+	uri := mustParseURL(t, "chan://closed")
+	if err := lp.RemoveListeners(uri); err != ErrProviderClosed {
+		t.Errorf("expected ErrProviderClosed, got %v", err)
+	}
+	if err := lp.RemoveNamedListener(uri, "foo"); err != ErrProviderClosed {
+		t.Errorf("expected ErrProviderClosed, got %v", err)
+	}
+}
+
+func TestManager_RemoveListeners_DelegatesToProvider(t *testing.T) {
+	mgr := GetManager()
+	uri := mustParseURL(t, "chan://manager-remove")
+
+	var fired atomic.Int32
+	assert.NoError(t, mgr.AddListener(uri, func(Message) { fired.Add(1) }))
+	assert.NoError(t, mgr.RemoveListeners(uri))
+
+	msg, _ := mgr.NewMessage("chan")
+	_, _ = msg.SetBodyStr("nope")
+	assert.NoError(t, mgr.Send(uri, msg))
+	time.Sleep(150 * time.Millisecond)
+	if fired.Load() != 0 {
+		t.Fatalf("manager RemoveListeners did not propagate; %d fires", fired.Load())
+	}
+}
+
+// TestManager_RemoveListeners_UnsupportedProvider verifies that a provider
+// not implementing ListenerRemover triggers ErrListenerRemovalUnsupported.
+func TestManager_RemoveListeners_UnsupportedProvider(t *testing.T) {
+	// Construct a fresh manager so we don't pollute the default one.
+	m := &managerImpl{knownProviders: make(map[string]Provider)}
+	// A bare Provider — Schemes/Id only, no listener-removal support.
+	bare := &bareProvider{}
+	m.Register(bare)
+	uri := mustParseURL(t, "bare://x")
+	err := m.RemoveListeners(uri)
+	if err != ErrListenerRemovalUnsupported {
+		t.Fatalf("expected ErrListenerRemovalUnsupported, got %v", err)
+	}
+	err = m.RemoveNamedListener(uri, "n")
+	if err != ErrListenerRemovalUnsupported {
+		t.Fatalf("expected ErrListenerRemovalUnsupported, got %v", err)
+	}
+}
+
+// bareProvider implements Provider but explicitly NOT ListenerRemover.
+type bareProvider struct{}
+
+func (p *bareProvider) Close() error                                             { return nil }
+func (p *bareProvider) Id() string                                               { return "bare" }
+func (p *bareProvider) Schemes() []string                                        { return []string{"bare"} }
+func (p *bareProvider) Setup() error                                             { return nil }
+func (p *bareProvider) NewMessage(string, ...Option) (Message, error)            { return nil, nil }
+func (p *bareProvider) Send(*url.URL, Message, ...Option) error                  { return nil }
+func (p *bareProvider) SendBatch(*url.URL, []Message, ...Option) error           { return nil }
+func (p *bareProvider) Receive(*url.URL, ...Option) (Message, error)             { return nil, nil }
+func (p *bareProvider) ReceiveBatch(*url.URL, ...Option) ([]Message, error)      { return nil, nil }
+func (p *bareProvider) AddListener(*url.URL, func(msg Message), ...Option) error { return nil }

--- a/messaging/manager.go
+++ b/messaging/manager.go
@@ -14,9 +14,14 @@ var mutex sync.Mutex
 // Manager interface defines an abstraction for messaging providers that can be registered
 type Manager interface {
 	Provider
+	ListenerRemover // delegated to providers that opt in to ListenerRemover
 	Wait()
 	Register(Provider)
 }
+
+// ErrListenerRemovalUnsupported is returned by manager methods when the
+// underlying provider for a URL scheme does not implement ListenerRemover.
+var ErrListenerRemovalUnsupported = fmt.Errorf("provider does not support listener removal")
 
 // managerImpl struct is used to manage the known Messaging providers.
 // It includes a mutex to handle concurrent access to the known providers
@@ -69,6 +74,36 @@ func (m *managerImpl) AddListener(u *url.URL, listener func(msg Message), option
 		err = provider.AddListener(u, listener, options...)
 	}
 	return
+}
+
+// RemoveListeners removes every listener for the URL via the matching
+// provider. Returns ErrListenerRemovalUnsupported when the provider for
+// the scheme does not implement ListenerRemover.
+func (m *managerImpl) RemoveListeners(u *url.URL) error {
+	provider, err := m.getFor(u.Scheme)
+	if err != nil {
+		return err
+	}
+	remover, ok := provider.(ListenerRemover)
+	if !ok {
+		return ErrListenerRemovalUnsupported
+	}
+	return remover.RemoveListeners(u)
+}
+
+// RemoveNamedListener removes the named-listener group for the URL via
+// the matching provider. Returns ErrListenerRemovalUnsupported when the
+// provider for the scheme does not implement ListenerRemover.
+func (m *managerImpl) RemoveNamedListener(u *url.URL, name string) error {
+	provider, err := m.getFor(u.Scheme)
+	if err != nil {
+		return err
+	}
+	remover, ok := provider.(ListenerRemover)
+	if !ok {
+		return ErrListenerRemovalUnsupported
+	}
+	return remover.RemoveNamedListener(u, name)
 }
 
 // ReceiveBatch receives a batch of messages using the appropriate provider

--- a/messaging/provider.go
+++ b/messaging/provider.go
@@ -25,6 +25,24 @@ type Receiver interface {
 	AddListener(*url.URL, func(msg Message), ...Option) error
 }
 
+// ListenerRemover is an optional capability a Receiver may implement to
+// support tearing down previously-registered listeners. Providers signal
+// support by satisfying this interface in addition to Receiver; callers
+// should type-assert before invoking.
+//
+// Implementations must be idempotent — removing listeners that aren't
+// registered (or for an unknown URL) is not an error.
+type ListenerRemover interface {
+	// RemoveListeners removes every listener registered for the URL.
+	// The destination channel itself remains open so Send/Receive continue
+	// to work. Returns nil if no listeners were registered (idempotent).
+	RemoveListeners(*url.URL) error
+	// RemoveNamedListener removes only the named-listener group for the URL,
+	// leaving other listeners on the same URL in place. Returns nil if the
+	// URL or name is unknown (idempotent).
+	RemoveNamedListener(*url.URL, string) error
+}
+
 // Provider interface exposes methods for a messaging provider
 // It includes Producer and Receiver interfaces
 // It also includes Schemes method to get the supported schemes,


### PR DESCRIPTION
## Description

Adds an optional `ListenerRemover` capability to the messaging package so callers can tear down previously-registered listeners. Closes #94 ("Add Stop Listener support to messaging Receiver"), which had identified that `Receiver` exposes `AddListener` with no removal counterpart.

### Related Issue

Closes #94

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ✅ Test update (adding or modifying tests)
- [ ] 🔨 Build / CI changes

## Changes Made

### New capability — `messaging.ListenerRemover`

```go
type ListenerRemover interface {
    RemoveListeners(*url.URL) error                // drop every listener for the URL
    RemoveNamedListener(*url.URL, string) error    // drop one named group
}
```

- Idempotent — removing non-existent listeners returns `nil`.
- Leaves the destination channel and dispatch goroutine intact, so `Send` / `Receive` and future `AddListener` calls continue to work.
- Added as a **separate interface from `Receiver`** so existing external implementations (`golly-aws/sqs`, `golly-gcp/pubsub`, third-party receivers) keep building without modification. They opt in by implementing `ListenerRemover` when ready.

### `LocalProvider` implements `ListenerRemover`

Both methods take the existing write lock and `delete()` from the appropriate map level (host or named group inside the host).

### `Manager` interface extends `ListenerRemover`

```go
type Manager interface {
    Provider
    ListenerRemover // new
    Wait()
    Register(Provider)
}
```

`managerImpl` delegates to the matching provider when it implements `ListenerRemover`, otherwise returns the new sentinel `messaging.ErrListenerRemovalUnsupported`.

## Testing

- [x] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

```
$ go test -race ./messaging/...
ok  	oss.nandlabs.io/golly/messaging	4.803s

$ go test -race ./... | tail -5
ok  	oss.nandlabs.io/golly/vfs        3.630s
ok  	oss.nandlabs.io/golly/ws         3.952s
ok  	oss.nandlabs.io/golly/ws/wsmux   3.509s
# All 30+ packages pass under -race; golangci-lint reports 0 issues.

$ go test -v ./messaging -run 'TestLocalProvider_RemoveListeners|TestLocalProvider_RemoveNamedListener|TestManager_RemoveListeners'
--- PASS: TestLocalProvider_RemoveListeners_DropsAll       (0.15s)
--- PASS: TestLocalProvider_RemoveListeners_Idempotent     (0.00s)
--- PASS: TestLocalProvider_RemoveNamedListener_LeavesOthers (0.15s)
--- PASS: TestLocalProvider_RemoveListeners_ClosedProvider (0.00s)
--- PASS: TestManager_RemoveListeners_DelegatesToProvider  (0.15s)
--- PASS: TestManager_RemoveListeners_UnsupportedProvider  (0.00s)
ok  	oss.nandlabs.io/golly/messaging
```

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (godoc on new types/methods)
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I agree my contribution may be redistributed under either the [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) license

## Additional Context

**Why a separate interface, not an extension of `Receiver`.**
Adding the methods to `Receiver` would break any external implementation that doesn't add the new methods — including `golly-aws/sqs` and `golly-gcp/pubsub`. With `ListenerRemover` as a separate optional interface, those providers continue to build today, can opt in at their own pace, and the manager surfaces a clean `ErrListenerRemovalUnsupported` until they do.

**API design rationale.** The two methods cover the two natural use cases:
- `RemoveListeners(url)` — component shutdown: "I'm done with everything on this URL."
- `RemoveNamedListener(url, name)` — granular: "scale this worker group down / replace it."

A handle-based `(ListenerID, error)` variant could be added later if a use case for per-listener removal appears; doing it now would require either breaking `AddListener` or adding a parallel `AddListenerWithID` — neither feels worth the API bloat without a concrete need.

**Zero new deps.** Stdlib only (`net/url`, `sync`).
