### PR TITLE
test(fuzz): add fuzz targets + fix ws/frame uint64 length overflow (closes #67)

### DIFF
--- a/codec/validator/jsonschema_fuzz_test.go
+++ b/codec/validator/jsonschema_fuzz_test.go
@@ -1,0 +1,86 @@
+package validator
+
+import (
+	"encoding/json"
+	"testing"
+
+	"oss.nandlabs.io/golly/data"
+)
+
+// FuzzCompileSchema asserts CompileSchema never panics when given arbitrary
+// JSON-decoded into a data.Schema. Malformed input must error rather than
+// crash.
+func FuzzCompileSchema(f *testing.F) {
+	seeds := []string{
+		`{}`,
+		`{"type":"string"}`,
+		`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`,
+		`{"type":"object","properties":{"a":{"type":"integer","minimum":0,"maximum":10}}}`,
+		`{"type":"array","items":{"type":"string"},"minItems":1}`,
+		`{"type":"string","pattern":"^[a-z]+$"}`,
+		`{"type":"string","pattern":"["}`, // invalid regex
+		`{"type":"object","properties":{"x":{"$ref":"#/definitions/x"}}}`,
+		`{"enum":[1,2,3]}`,
+		`{"oneOf":[{"type":"string"},{"type":"integer"}]}`,
+		`{"anyOf":[{"type":"string"}]}`,
+		`{"allOf":[{"type":"object"}]}`,
+		`{"type":"string","minLength":-1}`,
+		`{"type":"object","properties":{}}`,
+		`{"type":"object","minProperties":0,"maxProperties":1000}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		var s data.Schema
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return // not a valid schema doc — fine
+		}
+		_, _ = CompileSchema(&s) // must not panic; error is fine
+	})
+}
+
+// FuzzValidate asserts Validate never panics on arbitrary JSON-decoded data
+// against a fixed, moderately complex schema.
+func FuzzValidate(f *testing.F) {
+	schema := &data.Schema{
+		Type: "object",
+		Properties: map[string]*data.Schema{
+			"name": {Type: "string", MinLength: ptrInt(1), MaxLength: ptrInt(64)},
+			"age":  {Type: "integer", Minimum: ptrFloat(0), Maximum: ptrFloat(150)},
+			"tags": {Type: "array", Items: &data.Schema{Type: "string"}, MaxItems: ptrInt(10)},
+			"role": {Enum: []any{"admin", "user", "guest"}},
+		},
+		Required: []string{"name"},
+	}
+	v, err := CompileSchema(schema)
+	if err != nil {
+		f.Fatalf("seed schema failed to compile: %v", err)
+	}
+
+	seeds := []string{
+		`{"name":"Alice"}`,
+		`{"name":"Bob","age":30,"role":"admin"}`,
+		`{"name":""}`,
+		`{"age":"not-a-number"}`,
+		`null`,
+		`[]`,
+		`"plain string"`,
+		`{"name":"X","tags":["a","b","c"]}`,
+		`{"name":"X","tags":1}`,
+		`{"name":"X","role":"bad-role"}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		var value any
+		if err := json.Unmarshal(raw, &value); err != nil {
+			return // not valid JSON — fine
+		}
+		_ = v.Validate(value) // success or error are both fine; must not panic
+	})
+}
+
+func ptrInt(i int) *int           { return &i }
+func ptrFloat(f float64) *float64 { return &f }

--- a/genai/prompts_fuzz_test.go
+++ b/genai/prompts_fuzz_test.go
@@ -1,0 +1,43 @@
+package genai
+
+import (
+	"testing"
+)
+
+// FuzzPromptTemplate_NewAndFormat asserts that constructing a PromptTemplate
+// and then formatting it with an arbitrary parameter value never panics.
+// The template engine accepts both {placeholder} and Go-template syntaxes;
+// either malformed input must error rather than crash.
+func FuzzPromptTemplate_NewAndFormat(f *testing.F) {
+	type seed struct {
+		template string
+		key      string
+		value    string
+	}
+	seeds := []seed{
+		{"hello {name}", "name", "world"},
+		{"{a}+{b}={c}", "a", "1"},
+		{"plain text — no placeholders", "x", "y"},
+		{"unbalanced { brace", "x", "y"},
+		{"{nested {brace}}", "brace", "B"},
+		{"", "x", "y"},
+		{"{empty}", "empty", ""},
+		{"go template {{.Name}}", "Name", "G"},
+		{"mixed {hello} {{.Name}}", "hello", "H"},
+		{"{a} {a} {a}", "a", "repeat"},
+		{"{name}", "name", "\x00\x01\x02"},
+		{"{key with space}", "key with space", "v"},
+		{"{name", "name", "v"}, // unclosed
+		{"name}", "name", "v"}, // unopened
+	}
+	for _, s := range seeds {
+		f.Add(s.template, s.key, s.value)
+	}
+	f.Fuzz(func(t *testing.T, tmpl, key, val string) {
+		pt, err := NewPromptTemplate("fuzz", "fuzz-template", tmpl)
+		if err != nil {
+			return // malformed template — must error, not panic
+		}
+		_, _ = pt.Format(map[string]any{key: val})
+	})
+}

--- a/semver/fuzz_test.go
+++ b/semver/fuzz_test.go
@@ -1,0 +1,71 @@
+package semver
+
+import (
+	"testing"
+)
+
+// FuzzParse asserts Parse never panics on arbitrary input. Malformed input
+// must return an error rather than crash; well-formed input must round-trip
+// back to a string that re-parses cleanly.
+func FuzzParse(f *testing.F) {
+	seeds := []string{
+		"",
+		"0.0.0",
+		"1.2.3",
+		"v1.2.3",
+		"1.0.0-alpha",
+		"1.0.0-alpha.1",
+		"1.0.0-0.3.7",
+		"1.0.0-x.7.z.92",
+		"1.0.0+20130313144700",
+		"1.0.0-beta+exp.sha.5114f85",
+		"1.0.0+21AF26D3----117B344092BD",
+		"99999999999999999999999.999999999999999999.99999999999999999",
+		"1",
+		"1.2",
+		"1.2.3.4",
+		"a.b.c",
+		"-1.-2.-3",
+		"1.2.3-+",
+		"1.2.3-",
+		"1.2.3+",
+		"1.0.0-α",
+		"  1.2.3  ",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		v, err := Parse(s)
+		if err != nil {
+			return // invalid input — must not panic, but failure is OK
+		}
+		// Round-trip: a successfully parsed version should re-print to a
+		// non-empty string that also parses successfully.
+		out := v.String()
+		if out == "" {
+			t.Fatalf("Parse(%q) succeeded but String() empty", s)
+		}
+		if _, err := Parse(out); err != nil {
+			t.Fatalf("round-trip failed: Parse(%q) -> %q -> Parse error: %v", s, out, err)
+		}
+	})
+}
+
+// FuzzCompareRaw asserts CompareRaw never panics on arbitrary pair input.
+func FuzzCompareRaw(f *testing.F) {
+	seeds := [][2]string{
+		{"1.0.0", "1.0.0"},
+		{"1.0.0", "2.0.0"},
+		{"1.0.0-alpha", "1.0.0"},
+		{"", ""},
+		{"v1.2.3", "1.2.3"},
+		{"1.2.3-alpha+build", "1.2.3-alpha"},
+	}
+	for _, p := range seeds {
+		f.Add(p[0], p[1])
+	}
+	f.Fuzz(func(t *testing.T, a, b string) {
+		_, _ = CompareRaw(a, b) // success or error are both acceptable; must not panic
+	})
+}

--- a/ws/frame.go
+++ b/ws/frame.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 )
 
 // readFrame reads a single WebSocket frame from the reader.
@@ -58,8 +59,17 @@ func readFrame(r io.Reader, maxSize int64) (*frame, error) {
 		return nil, ErrControlTooLarge
 	}
 
-	// Check max message size
-	if maxSize > 0 && int64(payloadLen) > maxSize {
+	// RFC 6455 §5.2 forbids the most-significant bit being set in the 8-byte
+	// extended length, so payloadLen must fit in int64. We also cap at
+	// math.MaxInt to avoid make([]byte, payloadLen) overflowing on 32-bit
+	// systems even when no maxSize cap was supplied.
+	if payloadLen > math.MaxInt {
+		return nil, ErrMessageTooLarge
+	}
+	// Check max message size. Compare in the same unsigned space to avoid
+	// int64 sign-flip turning huge payloads into "negative > maxSize == false"
+	// and bypassing the cap.
+	if maxSize > 0 && payloadLen > uint64(maxSize) {
 		return nil, ErrMessageTooLarge
 	}
 

--- a/ws/frame_fuzz_test.go
+++ b/ws/frame_fuzz_test.go
@@ -1,0 +1,46 @@
+package ws
+
+import (
+	"bytes"
+	"testing"
+)
+
+// FuzzReadFrame asserts the RFC 6455 frame parser never panics on arbitrary
+// byte input. Untrusted bytes must either parse to a valid frame or return
+// an error — never crash.
+func FuzzReadFrame(f *testing.F) {
+	seeds := [][]byte{
+		// Minimal text frame, FIN=1, payload="hi"
+		{0x81, 0x02, 'h', 'i'},
+		// Empty payload
+		{0x81, 0x00},
+		// Masked frame from a client
+		{0x81, 0x82, 0x37, 0xfa, 0x21, 0x3d, 0x7f, 0x9f},
+		// 126-byte extended length
+		{0x82, 0x7e, 0x00, 0x7e},
+		// 65536-byte extended length (header only)
+		{0x82, 0x7f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00},
+		// Close frame
+		{0x88, 0x02, 0x03, 0xe8},
+		// Ping
+		{0x89, 0x00},
+		// Pong
+		{0x8a, 0x00},
+		// Continuation
+		{0x80, 0x01, 'x'},
+		// Truncated (1 byte)
+		{0x81},
+		// Empty
+		{},
+		// Garbage
+		{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// 64KiB cap mirrors a reasonable server-side default; the value
+		// limits memory the fuzzer can allocate per input.
+		_, _ = readFrame(bytes.NewReader(data), 64*1024)
+	})
+}

--- a/ws/testdata/fuzz/FuzzReadFrame/7a9bd47db0a9d710
+++ b/ws/testdata/fuzz/FuzzReadFrame/7a9bd47db0a9d710
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\x82\x7f\xe30000000")


### PR DESCRIPTION
## Description

Adds Go 1.18+ native fuzz targets at the canonical input-parsing boundaries in golly, plus a fix for a real overflow bug the new ws frame fuzzer surfaced on its first run.

### Related Issue

Closes #67

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue) — ws frame uint64-length overflow
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ✅ Test update (adding or modifying tests)
- [ ] 🔨 Build / CI changes

## Changes Made

### New fuzz targets (zero new deps — stdlib `testing.F`)

| Package | Targets | What it asserts |
|---|---|---|
| `semver` | `FuzzParse`, `FuzzCompareRaw` | `Parse` never panics; successful parses round-trip; `CompareRaw` never panics |
| `codec/validator` | `FuzzCompileSchema`, `FuzzValidate` | `CompileSchema(*data.Schema)` never panics on arbitrary JSON-decoded schemas; `Validate` never panics against a fixed moderately-complex schema |
| `ws` | `FuzzReadFrame` | RFC 6455 frame parser never panics on arbitrary bytes (any cap, including 64KiB default) |
| `genai` | `FuzzPromptTemplate_NewAndFormat` | Template construction + format with arbitrary inputs never panics |

Each target ships a seed corpus of known-good and known-malformed inputs. Local dry runs at `-fuzztime=3s` per target totalled **~1.65M execs / 0 crashes** after the fix below.

### Bug fix — `ws/frame.go` uint64 payload-length overflow 🐛

The fuzzer caught a real bug immediately:

```
panic: runtime error: makeslice: len out of range
  ws.readFrame()  frame.go:75
```

Triggered by any 64-bit extended-length frame with the most-significant bit set (e.g. `\x82\x7f\xe3...`). Root cause was at `frame.go:62`:

```go
// before
if maxSize > 0 && int64(payloadLen) > maxSize {  // payloadLen is uint64
```

`int64(0xe300000000000000)` is **negative**, so the comparison was `false` regardless of `maxSize`. The cap was bypassed and `make([]byte, payloadLen)` crashed.

**Fix:**
```go
// after
if payloadLen > math.MaxInt {
    return nil, ErrMessageTooLarge // RFC 6455 §5.2 requires MSB=0 anyway
}
if maxSize > 0 && payloadLen > uint64(maxSize) {
    return nil, ErrMessageTooLarge // compare in unsigned space, no sign-flip
}
```

The crashing seed (`ws/testdata/fuzz/FuzzReadFrame/7a9bd47db0a9d710`) is committed and now runs as a regular regression test on every `go test ./ws` invocation — it'll catch any future regression even without explicit fuzzing.

## Testing

- [x] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

```
$ go test -race ./...
# 30+ packages pass; ws now includes the regression for the saved fuzz crash.

$ go test -run Fuzz -fuzz FuzzReadFrame -fuzztime 5s ./ws
fuzz: elapsed: 5s, execs: 552854 (109624/sec), new interesting: 11
PASS

$ go test -run Fuzz -fuzz FuzzParse -fuzztime 3s ./semver
fuzz: elapsed: 3s, execs: 455167 (151717/sec), new interesting: 49
PASS

$ go test -run Fuzz -fuzz FuzzCompileSchema -fuzztime 2s ./codec/validator
fuzz: elapsed: 2s, execs: 328064 (146759/sec), new interesting: 132
PASS

$ go test -run Fuzz -fuzz FuzzValidate -fuzztime 3s ./codec/validator
fuzz: elapsed: 3s, execs: 315426 (105138/sec), new interesting: 158
PASS

$ go test -run Fuzz -fuzz FuzzPromptTemplate_NewAndFormat -fuzztime 3s ./genai
fuzz: elapsed: 3s, execs: 372289 (124093/sec), new interesting: 251
PASS

$ golangci-lint run
0 issues.
```

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I agree my contribution may be redistributed under either the [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) license

## Additional Context

**Fuzz-testing hygiene.** Each new `Fuzz*` function is a normal Go test that runs in `go test ./…` against its committed seed corpus — including the new regression seed for the ws bug. To actually fuzz (generate new inputs), run `go test -run=^$ -fuzz=FuzzReadFrame -fuzztime=30s ./ws` locally. Worth considering a scheduled CI job that fuzzes for ~30s per target per day to keep finding new corner cases over time.

**Why these targets first.** They cover the high-leverage parsing surfaces where untrusted input lands: a version string from a user, a JSON Schema from a config, bytes off the wire from a WebSocket client, a template string from a prompt store. Other candidates (codec JSON/YAML decoders, config properties parser, `data.Pipeline.Get`) are good follow-on targets — they can go in a second PR once this approach is reviewed.
