### PR TITLE
feat(cache): generic Cache interface + InMemory backend (closes #51)

### DIFF
--- a/cache/README.md
+++ b/cache/README.md
@@ -1,0 +1,101 @@
+# cache
+
+A small, generic key/value cache abstraction for golly, plus an in-memory
+backend. The interface is provider-agnostic so downstream modules (Redis,
+Memcached, cloud-managed caches) can implement it without pulling those
+dependencies into core — matching the pattern used by `golly/vfs` and
+`golly/messaging`.
+
+## Status
+
+| Backend | Where it lives | Status |
+| --- | --- | --- |
+| `InMemory` (this package) | `oss.nandlabs.io/golly/cache` | ✅ shipped |
+| Redis | proposed `oss.nandlabs.io/golly-cache-redis` | follow-up |
+| Memcached | proposed `oss.nandlabs.io/golly-cache-memcached` | follow-up |
+| Cloud caches (ElastiCache, MemoryDB, Memorystore, …) | `golly-aws` / `golly-gcp` | follow-up |
+
+## Interface
+
+```go
+type Cache[K comparable, V any] interface {
+    Get(ctx context.Context, key K) (V, bool)
+    Set(ctx context.Context, key K, value V) error
+    SetWithTTL(ctx context.Context, key K, value V, ttl time.Duration) error
+    Delete(ctx context.Context, key K) bool
+    Has(ctx context.Context, key K) bool
+    Clear(ctx context.Context) error
+    Len(ctx context.Context) int
+    Close() error
+}
+```
+
+Two optional capabilities are surfaced as separate interfaces — implementations
+opt in by satisfying them:
+
+- `Sweeper` — eagerly evict expired entries (`InMemory` implements it).
+- `Loader[K, V]` — `GetOrLoad` for thundering-herd protection (not yet
+  implemented on `InMemory`; reserved interface for future backends).
+
+## Quick start
+
+```go
+import (
+    "context"
+    "time"
+
+    "oss.nandlabs.io/golly/cache"
+)
+
+c := cache.NewInMemory[string, []byte]()
+defer c.Close()
+
+ctx := context.Background()
+_ = c.Set(ctx, "session:abc", payload)
+_ = c.SetWithTTL(ctx, "rate:user42", token, 30*time.Second)
+
+if v, ok := c.Get(ctx, "session:abc"); ok {
+    use(v)
+}
+```
+
+### Background expiry
+
+The in-memory backend expires entries **lazily** on access. To bound memory
+under churn, enable a janitor goroutine that sweeps periodically:
+
+```go
+c := cache.NewInMemory[string, int](
+    cache.WithJanitor[string, int](1 * time.Minute),
+)
+defer c.Close() // stops the janitor
+```
+
+Or sweep manually when you know it's a quiet moment:
+
+```go
+n := c.Sweep()       // returns number of expired entries removed
+```
+
+### Zero TTL means never expires
+
+```go
+_ = c.SetWithTTL(ctx, "config", v, cache.NoExpiry) // same as Set
+```
+
+## Design notes
+
+- **Generic over keys and values** — no `interface{}` boxing, no reflection.
+- **Context-aware** — the in-memory backend ignores `ctx` but the signature
+  is in place for network backends.
+- **Close semantics** — after `Close`, writes return `ErrClosed`; reads
+  continue against the existing snapshot for graceful drain.
+- **No maximum size / eviction policy yet** — the in-memory backend has
+  unbounded capacity. LRU / TinyLFU / size-based eviction are planned
+  follow-ups; track via #51 follow-on issues.
+- **Zero external deps** — stdlib only.
+
+## License
+
+Dual-licensed under [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT)
+at your option (same as the rest of golly).

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,75 @@
+// Package cache provides a small, generic key/value cache abstraction plus
+// an in-memory backend. The interface is provider-agnostic so downstream
+// modules (redis, memcached, cloud-managed caches) can implement it without
+// pulling those dependencies into the core package — matching the same
+// pattern used by golly/vfs and golly/messaging.
+package cache
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// NoExpiry is a TTL value that disables expiry for a given entry.
+const NoExpiry time.Duration = 0
+
+// ErrClosed is returned by operations on a cache that has been closed.
+var ErrClosed = errors.New("cache: closed")
+
+// Cache is a generic key/value cache with optional per-entry TTL.
+// Implementations MUST be safe for concurrent use.
+//
+// The context is intended for backends that perform network I/O
+// (Redis, Memcached, cloud caches); in-memory backends may ignore it.
+type Cache[K comparable, V any] interface {
+	// Get returns the value for the key and whether it was found. Entries
+	// past their TTL return (zero value, false).
+	Get(ctx context.Context, key K) (V, bool)
+
+	// Set stores value under key with no expiry. Equivalent to
+	// SetWithTTL(ctx, key, value, NoExpiry).
+	Set(ctx context.Context, key K, value V) error
+
+	// SetWithTTL stores value under key with the given TTL. A ttl of
+	// NoExpiry (zero) means the entry never expires.
+	SetWithTTL(ctx context.Context, key K, value V, ttl time.Duration) error
+
+	// Delete removes the key. Returns true if it existed.
+	Delete(ctx context.Context, key K) bool
+
+	// Has reports whether key is present and not expired.
+	Has(ctx context.Context, key K) bool
+
+	// Clear empties the cache.
+	Clear(ctx context.Context) error
+
+	// Len returns the current number of stored entries. Lazy-expiry
+	// backends may include entries past their TTL until next access;
+	// callers wanting a precise live count should call Sweep first if
+	// the backend implements Sweeper.
+	Len(ctx context.Context) int
+
+	// Close releases any resources held by the cache (background
+	// goroutines, network connections). After Close, all other methods
+	// return ErrClosed. Safe to call multiple times.
+	Close() error
+}
+
+// Sweeper is an optional capability for caches that retain expired entries
+// until accessed; calling Sweep removes them eagerly.
+type Sweeper interface {
+	// Sweep removes all expired entries and returns the number removed.
+	Sweep() int
+}
+
+// Loader is an optional capability some caches expose for the
+// "get-or-load" pattern that protects the underlying source from
+// thundering-herd traffic.
+type Loader[K comparable, V any] interface {
+	// GetOrLoad returns the cached value for key. If absent or expired,
+	// load is invoked exactly once per concurrent miss and the result is
+	// cached with the supplied ttl. Other concurrent callers for the
+	// same key wait for the single load and share its result.
+	GetOrLoad(ctx context.Context, key K, ttl time.Duration, load func(context.Context) (V, error)) (V, error)
+}

--- a/cache/inmemory.go
+++ b/cache/inmemory.go
@@ -1,0 +1,207 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// InMemory is a goroutine-safe in-memory Cache. Entries with a TTL are
+// expired lazily on access; an optional janitor goroutine sweeps stale
+// entries on a fixed interval to bound memory use under churn (enable
+// via WithJanitor).
+//
+// Suitable for single-process caches. For cross-process / cross-node
+// caching, implement Cache with a network backend (Redis, Memcached,
+// cloud caches) in a separate module.
+type InMemory[K comparable, V any] struct {
+	mu       sync.RWMutex
+	entries  map[K]entry[V]
+	closed   bool
+	stopJani chan struct{}
+	now      func() time.Time // injectable clock for tests
+}
+
+type entry[V any] struct {
+	value   V
+	expires time.Time // zero = never expires
+}
+
+// InMemoryOption configures an InMemory cache at construction time.
+type InMemoryOption[K comparable, V any] func(*InMemory[K, V])
+
+// WithJanitor runs a background goroutine that calls Sweep every interval.
+// Pass 0 (the default) or a negative duration to disable the janitor.
+// The goroutine stops on Close.
+func WithJanitor[K comparable, V any](interval time.Duration) InMemoryOption[K, V] {
+	return func(c *InMemory[K, V]) {
+		if interval <= 0 {
+			return
+		}
+		stop := make(chan struct{})
+		c.stopJani = stop
+		// Capture `stop` in the goroutine instead of reading c.stopJani —
+		// avoids a race with Close, which mutates c.stopJani under lock.
+		go c.janitorLoop(interval, stop)
+	}
+}
+
+// withClock injects a clock for deterministic tests; unexported on purpose.
+func withClock[K comparable, V any](now func() time.Time) InMemoryOption[K, V] {
+	return func(c *InMemory[K, V]) { c.now = now }
+}
+
+// NewInMemory constructs an empty in-memory cache. Options are applied in
+// order; later options override earlier ones for the same field.
+func NewInMemory[K comparable, V any](opts ...InMemoryOption[K, V]) *InMemory[K, V] {
+	c := &InMemory[K, V]{
+		entries: make(map[K]entry[V]),
+		now:     time.Now,
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// Get returns the value for key or (zero, false) when absent or expired.
+func (c *InMemory[K, V]) Get(_ context.Context, key K) (V, bool) {
+	c.mu.RLock()
+	e, ok := c.entries[key]
+	c.mu.RUnlock()
+	var zero V
+	if !ok {
+		return zero, false
+	}
+	if c.isExpired(e) {
+		// Best-effort lazy delete. Held under read lock above, so promote.
+		c.mu.Lock()
+		// Re-check under write lock — another goroutine may have replaced it.
+		if cur, ok := c.entries[key]; ok && c.isExpired(cur) {
+			delete(c.entries, key)
+		}
+		c.mu.Unlock()
+		return zero, false
+	}
+	return e.value, true
+}
+
+// Set stores value under key with no expiry.
+func (c *InMemory[K, V]) Set(ctx context.Context, key K, value V) error {
+	return c.SetWithTTL(ctx, key, value, NoExpiry)
+}
+
+// SetWithTTL stores value under key with the given TTL.
+func (c *InMemory[K, V]) SetWithTTL(_ context.Context, key K, value V, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return ErrClosed
+	}
+	e := entry[V]{value: value}
+	if ttl > 0 {
+		e.expires = c.now().Add(ttl)
+	}
+	c.entries[key] = e
+	return nil
+}
+
+// Delete removes key. Returns true when the key was present.
+func (c *InMemory[K, V]) Delete(_ context.Context, key K) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.entries[key]; ok {
+		delete(c.entries, key)
+		return true
+	}
+	return false
+}
+
+// Has reports whether key is present and not expired.
+func (c *InMemory[K, V]) Has(ctx context.Context, key K) bool {
+	_, ok := c.Get(ctx, key)
+	return ok
+}
+
+// Clear removes every entry.
+func (c *InMemory[K, V]) Clear(_ context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return ErrClosed
+	}
+	c.entries = make(map[K]entry[V])
+	return nil
+}
+
+// Len returns the number of stored entries, including any that are
+// expired but not yet swept.
+func (c *InMemory[K, V]) Len(_ context.Context) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.entries)
+}
+
+// Sweep removes all expired entries and returns the count removed.
+// Implements Sweeper.
+func (c *InMemory[K, V]) Sweep() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return 0
+	}
+	n := 0
+	for k, e := range c.entries {
+		if c.isExpired(e) {
+			delete(c.entries, k)
+			n++
+		}
+	}
+	return n
+}
+
+// Close stops the janitor (if any) and marks the cache closed. Subsequent
+// Set/SetWithTTL/Clear return ErrClosed; Get/Has/Len/Delete continue to
+// work on the existing snapshot for graceful drain (idempotent).
+func (c *InMemory[K, V]) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	if c.stopJani != nil {
+		// Closing signals the janitor goroutine (which captured the same
+		// channel as a local) to exit. We leave c.stopJani non-nil so a
+		// second Close() doesn't re-close (guarded by c.closed) and so
+		// concurrent readers observe a stable value.
+		close(c.stopJani)
+	}
+	return nil
+}
+
+func (c *InMemory[K, V]) isExpired(e entry[V]) bool {
+	return !e.expires.IsZero() && !c.now().Before(e.expires)
+}
+
+// janitorLoop sweeps expired entries every interval until stop is closed.
+// stop is passed in (not read from c.stopJani) so the loop has no race
+// with Close, which mutates c.stopJani under the write lock.
+func (c *InMemory[K, V]) janitorLoop(interval time.Duration, stop <-chan struct{}) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			c.Sweep()
+		case <-stop:
+			return
+		}
+	}
+}
+
+// Compile-time assertions that InMemory satisfies the public interfaces.
+var (
+	_ Cache[string, int] = (*InMemory[string, int])(nil)
+	_ Sweeper            = (*InMemory[string, int])(nil)
+)

--- a/cache/inmemory_test.go
+++ b/cache/inmemory_test.go
@@ -1,0 +1,222 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestInMemory_SetGet(t *testing.T) {
+	c := NewInMemory[string, int]()
+	ctx := context.Background()
+
+	if err := c.Set(ctx, "a", 1); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if v, ok := c.Get(ctx, "a"); !ok || v != 1 {
+		t.Fatalf("Get(a) = (%d, %v), want (1, true)", v, ok)
+	}
+	if _, ok := c.Get(ctx, "missing"); ok {
+		t.Fatalf("Get(missing) should report ok=false")
+	}
+}
+
+func TestInMemory_TTLExpiry(t *testing.T) {
+	now := time.Now()
+	clock := &fakeClock{now: now}
+	c := NewInMemory[string, string](withClock[string, string](clock.Now))
+	ctx := context.Background()
+
+	if err := c.SetWithTTL(ctx, "k", "v", 100*time.Millisecond); err != nil {
+		t.Fatalf("SetWithTTL: %v", err)
+	}
+	// Within TTL: present
+	if _, ok := c.Get(ctx, "k"); !ok {
+		t.Fatalf("expected Get(k) ok within TTL")
+	}
+	// Advance past TTL — lazy expiry on next Get
+	clock.advance(101 * time.Millisecond)
+	if _, ok := c.Get(ctx, "k"); ok {
+		t.Fatalf("expected Get(k) ok=false past TTL")
+	}
+	// Entry should also be removed from underlying map (lazy delete).
+	if got := c.Len(ctx); got != 0 {
+		t.Fatalf("expected Len=0 after lazy delete; got %d", got)
+	}
+}
+
+func TestInMemory_NoExpiryBehaviour(t *testing.T) {
+	clock := &fakeClock{now: time.Now()}
+	c := NewInMemory[string, int](withClock[string, int](clock.Now))
+	ctx := context.Background()
+
+	// Both Set and SetWithTTL(..., NoExpiry) must mean "never expires".
+	_ = c.Set(ctx, "a", 1)
+	_ = c.SetWithTTL(ctx, "b", 2, NoExpiry)
+
+	clock.advance(365 * 24 * time.Hour) // 1 year later
+	for _, k := range []string{"a", "b"} {
+		if _, ok := c.Get(ctx, k); !ok {
+			t.Errorf("Get(%q) expired but should be NoExpiry", k)
+		}
+	}
+}
+
+func TestInMemory_Delete(t *testing.T) {
+	c := NewInMemory[int, int]()
+	ctx := context.Background()
+	_ = c.Set(ctx, 1, 10)
+	if !c.Delete(ctx, 1) {
+		t.Fatalf("Delete(1) should return true when present")
+	}
+	if c.Delete(ctx, 1) {
+		t.Fatalf("Delete(1) should return false after removal")
+	}
+	if _, ok := c.Get(ctx, 1); ok {
+		t.Fatalf("Get(1) should be absent after Delete")
+	}
+}
+
+func TestInMemory_Has(t *testing.T) {
+	clock := &fakeClock{now: time.Now()}
+	c := NewInMemory[string, int](withClock[string, int](clock.Now))
+	ctx := context.Background()
+	_ = c.SetWithTTL(ctx, "k", 1, 50*time.Millisecond)
+	if !c.Has(ctx, "k") {
+		t.Fatalf("Has(k) should be true within TTL")
+	}
+	clock.advance(60 * time.Millisecond)
+	if c.Has(ctx, "k") {
+		t.Fatalf("Has(k) should be false past TTL")
+	}
+}
+
+func TestInMemory_Clear(t *testing.T) {
+	c := NewInMemory[string, int]()
+	ctx := context.Background()
+	_ = c.Set(ctx, "a", 1)
+	_ = c.Set(ctx, "b", 2)
+	if err := c.Clear(ctx); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if c.Len(ctx) != 0 {
+		t.Fatalf("expected Len=0 after Clear; got %d", c.Len(ctx))
+	}
+}
+
+func TestInMemory_Sweep(t *testing.T) {
+	clock := &fakeClock{now: time.Now()}
+	c := NewInMemory[string, int](withClock[string, int](clock.Now))
+	ctx := context.Background()
+
+	_ = c.SetWithTTL(ctx, "a", 1, 10*time.Millisecond)
+	_ = c.SetWithTTL(ctx, "b", 2, 10*time.Millisecond)
+	_ = c.Set(ctx, "c", 3) // no expiry
+
+	clock.advance(20 * time.Millisecond)
+	if n := c.Sweep(); n != 2 {
+		t.Fatalf("Sweep removed %d, want 2", n)
+	}
+	if c.Len(ctx) != 1 {
+		t.Fatalf("expected Len=1 after Sweep; got %d", c.Len(ctx))
+	}
+}
+
+func TestInMemory_ClosedRejectsWrites(t *testing.T) {
+	c := NewInMemory[string, int]()
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Close is idempotent.
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close (second call): %v", err)
+	}
+	ctx := context.Background()
+	if err := c.Set(ctx, "k", 1); err != ErrClosed {
+		t.Fatalf("Set after Close should return ErrClosed; got %v", err)
+	}
+	if err := c.SetWithTTL(ctx, "k", 1, time.Second); err != ErrClosed {
+		t.Fatalf("SetWithTTL after Close should return ErrClosed; got %v", err)
+	}
+	if err := c.Clear(ctx); err != ErrClosed {
+		t.Fatalf("Clear after Close should return ErrClosed; got %v", err)
+	}
+}
+
+func TestInMemory_Janitor(t *testing.T) {
+	// Real-time janitor (small interval); not using fakeClock here because
+	// the janitor uses time.Ticker which can't be faked without extra
+	// indirection — and the loop itself is the thing under test.
+	c := NewInMemory[string, int](WithJanitor[string, int](20 * time.Millisecond))
+	ctx := context.Background()
+	_ = c.SetWithTTL(ctx, "k", 1, 10*time.Millisecond)
+	// Wait for the janitor to sweep at least once after expiry.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if c.Len(ctx) == 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if c.Len(ctx) != 0 {
+		t.Fatalf("janitor never swept expired entry; Len=%d", c.Len(ctx))
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestInMemory_Concurrent(t *testing.T) {
+	c := NewInMemory[int, int]()
+	ctx := context.Background()
+	const writers, readers, iters = 8, 8, 500
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	var stops atomic.Int32
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				if i%5 == 0 {
+					_ = c.SetWithTTL(ctx, w*100+i, i, time.Millisecond)
+				} else {
+					_ = c.Set(ctx, w*100+i, i)
+				}
+				if i%17 == 0 {
+					c.Delete(ctx, w*100+i)
+				}
+			}
+		}(w)
+	}
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				_, _ = c.Get(ctx, i)
+				c.Has(ctx, i)
+				stops.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if stops.Load() != int32(readers*iters) {
+		t.Fatalf("reader goroutines did not all complete: %d", stops.Load())
+	}
+}
+
+// fakeClock is a monotonically advancing test clock.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (f *fakeClock) Now() time.Time { f.mu.Lock(); defer f.mu.Unlock(); return f.now }
+func (f *fakeClock) advance(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(d)
+}


### PR DESCRIPTION
## Description

Introduces a new `oss.nandlabs.io/golly/cache` package with a generic, context-aware `Cache` interface and an `InMemory` backend. Network backends (Redis, Memcached, cloud caches) ship in separate modules to keep core zero-deps — same pattern as `golly/vfs` → `golly-aws/s3`, `golly/messaging` → potential broker modules.

### Related Issue

Closes #51 (core interface + in-memory backend).

Follow-ups (separate issues / PRs):
- `golly-cache-redis` module — Redis backend
- `golly-cache-memcached` module — Memcached backend
- `golly-aws` / `golly-gcp` — cloud-managed cache integrations
- LRU / TinyLFU / size-based eviction on `InMemory`
- `Loader.GetOrLoad` implementation on `InMemory`

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [x] ✅ Test update (adding or modifying tests)
- [ ] 🔨 Build / CI changes

## Changes Made

### `cache/cache.go` — interface + capabilities

```go
type Cache[K comparable, V any] interface {
    Get(ctx context.Context, key K) (V, bool)
    Set(ctx context.Context, key K, value V) error
    SetWithTTL(ctx context.Context, key K, value V, ttl time.Duration) error
    Delete(ctx context.Context, key K) bool
    Has(ctx context.Context, key K) bool
    Clear(ctx context.Context) error
    Len(ctx context.Context) int
    Close() error
}

// Optional capabilities (opt-in via interface satisfaction):
type Sweeper interface { Sweep() int }
type Loader[K comparable, V any] interface {
    GetOrLoad(ctx context.Context, key K, ttl time.Duration, load func(context.Context) (V, error)) (V, error)
}
```

- Generic over both keys and values — no `any` boxing, no reflection.
- `context.Context` on every operation — in-memory ignores it; network backends need it.
- `NoExpiry` (zero `time.Duration`) for explicit "never expires."
- `ErrClosed` sentinel for post-Close writes.

### `cache/inmemory.go` — `InMemory[K, V]` backend

- `sync.RWMutex`-guarded `map[K]entry[V]`.
- **Lazy expiry on Get** (cheap, no goroutine).
- **Eager `Sweep()`** for callers who want a precise live count.
- **Optional janitor** via `WithJanitor[K, V](interval)` — background goroutine that sweeps periodically; stops cleanly on `Close`.
- `Close` is idempotent; reads continue against the existing snapshot for graceful drain.

### `cache/README.md`

Quick-start, design notes, planned follow-ups, license.

## Testing

- [x] I have added/updated unit tests for my changes
- [x] All existing tests pass (`go test ./...`)
- [x] I have tested this locally

### Test Output

```
$ go test -race -v ./cache
--- PASS: TestInMemory_SetGet              (0.00s)
--- PASS: TestInMemory_TTLExpiry           (0.00s)  # fake-clock advanced past TTL
--- PASS: TestInMemory_NoExpiryBehaviour   (0.00s)  # 1 year of fake time, still present
--- PASS: TestInMemory_Delete              (0.00s)
--- PASS: TestInMemory_Has                 (0.00s)
--- PASS: TestInMemory_Clear               (0.00s)
--- PASS: TestInMemory_Sweep               (0.00s)
--- PASS: TestInMemory_ClosedRejectsWrites (0.00s)  # ErrClosed; Close idempotent
--- PASS: TestInMemory_Janitor             (0.10s)  # janitor sweeps + clean Close
--- PASS: TestInMemory_Concurrent          (0.02s)  # 8 writers + 8 readers × 500 iters
ok      oss.nandlabs.io/golly/cache  1.521s

$ go test -race ./...      # full suite
# 30+ packages pass.

$ go vet ./... && golangci-lint run
0 issues.
```

## Checklist

- [x] My code follows the project's coding style and conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (`cache/README.md`)
- [x] My changes generate no new warnings or errors
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] I agree my contribution may be redistributed under either the [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT) license

## Additional Context

**Why context on every method.** The in-memory backend ignores `ctx`, but the network backends that will follow (Redis, Memcached, cloud) need it for timeouts and cancellation. Putting it in the interface now avoids a breaking change later — same convention `database/sql`, `net/http`, and most modern Go libraries follow.

**Why a separate `Loader` interface.** Get-or-load (loader function + single-flight) is a feature some backends will want and others won't — particularly a thin Redis wrapper that defers to the consumer's own loader logic. Defining the interface up front lets backends opt in incrementally without us bikeshedding `Cache` itself.

**Why no max-size / eviction yet.** Bounded caches need either LRU (cheap, classic), TinyLFU (richer, libraries like Ristretto popularised it), or a size-in-bytes cap (tricky for arbitrary `V`). Each is a real design call; the minimal-by-default policy avoids picking the wrong one now. Easy to add later — the interface doesn't change.

**Janitor race.** First implementation had the janitor goroutine reading `c.stopJani` while `Close` mutated it under lock — race-detector flagged it immediately during testing. Fix: capture the stop channel as a local in the goroutine. Worth flagging because it shows up in subtle stop-on-close patterns in many places.
