### PR TITLE
feat(vfs): VFileSystemCtx + critique fixes (#3-#8) — closes #104

### DIFF
--- a/examples/vfs/main.go
+++ b/examples/vfs/main.go
@@ -41,7 +41,7 @@ func main() {
 		fmt.Println("Open error:", err)
 		return
 	}
-	content, err := file.AsString()
+	content, err := vfs.ReadAllString(file)
 	if err != nil {
 		fmt.Println("Read error:", err)
 	} else {

--- a/vfs/context.go
+++ b/vfs/context.go
@@ -1,0 +1,135 @@
+package vfs
+
+import (
+	"context"
+	"net/url"
+)
+
+// VFileSystemCtx is an optional capability a VFileSystem may implement to
+// support context-aware variants of the I/O-heavy operations. Providers
+// signal support by satisfying this interface in addition to VFileSystem.
+//
+// Callers should prefer the package-level helpers (OpenCtx, CreateCtx,
+// CopyCtx, …) rather than type-asserting directly — the helpers fall back
+// to the non-ctx methods with best-effort cancellation when a backend
+// does not implement VFileSystemCtx.
+//
+// Network-backed implementations (S3, GCS, Azure Blob, etc.) should
+// implement VFileSystemCtx so the context propagates into the underlying
+// SDK call for genuine cancellation and deadline support. Local-filesystem
+// implementations gain little from implementing it directly, since the
+// underlying os package does not accept a context — the fallback path
+// already provides wait-level cancellation.
+type VFileSystemCtx interface {
+	OpenCtx(ctx context.Context, u *url.URL) (VFile, error)
+	CreateCtx(ctx context.Context, u *url.URL) (VFile, error)
+	DeleteCtx(ctx context.Context, u *url.URL) error
+	ListCtx(ctx context.Context, u *url.URL) ([]VFile, error)
+	MkdirAllCtx(ctx context.Context, u *url.URL) (VFile, error)
+	CopyCtx(ctx context.Context, src, dst *url.URL) error
+	MoveCtx(ctx context.Context, src, dst *url.URL) error
+	WalkCtx(ctx context.Context, u *url.URL, fn WalkFn) error
+}
+
+// runCtx runs op in a goroutine and races it against ctx cancellation.
+// On ctx cancellation, returns ctx.Err() — op may still complete in the
+// background (the underlying syscall is not cancellable). This is
+// best-effort cancellation: callers regain control immediately, but
+// running work cannot always be terminated. Network backends that fully
+// support context should implement VFileSystemCtx directly instead.
+func runCtx[T any](ctx context.Context, op func() (T, error)) (T, error) {
+	type result struct {
+		v   T
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		v, err := op()
+		done <- result{v, err}
+	}()
+	select {
+	case r := <-done:
+		return r.v, r.err
+	case <-ctx.Done():
+		var zero T
+		return zero, ctx.Err()
+	}
+}
+
+// runCtxErr is the void-returning variant of runCtx for ops that only
+// return error.
+func runCtxErr(ctx context.Context, op func() error) error {
+	_, err := runCtx(ctx, func() (struct{}, error) {
+		return struct{}{}, op()
+	})
+	return err
+}
+
+// OpenCtx opens u with the given context. If fs implements VFileSystemCtx
+// the call is delegated; otherwise it runs Open in a goroutine and races
+// it against ctx.
+func OpenCtx(ctx context.Context, fs VFileSystem, u *url.URL) (VFile, error) {
+	if v, ok := fs.(VFileSystemCtx); ok {
+		return v.OpenCtx(ctx, u)
+	}
+	return runCtx(ctx, func() (VFile, error) { return fs.Open(u) })
+}
+
+// CreateCtx mirrors VFileSystem.Create with context support.
+func CreateCtx(ctx context.Context, fs VFileSystem, u *url.URL) (VFile, error) {
+	if v, ok := fs.(VFileSystemCtx); ok {
+		return v.CreateCtx(ctx, u)
+	}
+	return runCtx(ctx, func() (VFile, error) { return fs.Create(u) })
+}
+
+// DeleteCtx mirrors VFileSystem.Delete with context support.
+func DeleteCtx(ctx context.Context, fs VFileSystem, u *url.URL) error {
+	if v, ok := fs.(VFileSystemCtx); ok {
+		return v.DeleteCtx(ctx, u)
+	}
+	return runCtxErr(ctx, func() error { return fs.Delete(u) })
+}
+
+// ListCtx mirrors VFileSystem.List with context support.
+func ListCtx(ctx context.Context, fs VFileSystem, u *url.URL) ([]VFile, error) {
+	if v, ok := fs.(VFileSystemCtx); ok {
+		return v.ListCtx(ctx, u)
+	}
+	return runCtx(ctx, func() ([]VFile, error) { return fs.List(u) })
+}
+
+// MkdirAllCtx mirrors VFileSystem.MkdirAll with context support.
+func MkdirAllCtx(ctx context.Context, fs VFileSystem, u *url.URL) (VFile, error) {
+	if v, ok := fs.(VFileSystemCtx); ok {
+		return v.MkdirAllCtx(ctx, u)
+	}
+	return runCtx(ctx, func() (VFile, error) { return fs.MkdirAll(u) })
+}
+
+// CopyCtx mirrors VFileSystem.Copy with context support.
+func CopyCtx(ctx context.Context, fs VFileSystem, src, dst *url.URL) error {
+	if v, ok := fs.(VFileSystemCtx); ok {
+		return v.CopyCtx(ctx, src, dst)
+	}
+	return runCtxErr(ctx, func() error { return fs.Copy(src, dst) })
+}
+
+// MoveCtx mirrors VFileSystem.Move with context support.
+func MoveCtx(ctx context.Context, fs VFileSystem, src, dst *url.URL) error {
+	if v, ok := fs.(VFileSystemCtx); ok {
+		return v.MoveCtx(ctx, src, dst)
+	}
+	return runCtxErr(ctx, func() error { return fs.Move(src, dst) })
+}
+
+// WalkCtx mirrors VFileSystem.Walk with context support. The fn callback
+// is invoked synchronously from the same goroutine running Walk, so it
+// must not block indefinitely; callers wanting per-file ctx checking
+// should test ctx.Err() inside fn.
+func WalkCtx(ctx context.Context, fs VFileSystem, u *url.URL, fn WalkFn) error {
+	if v, ok := fs.(VFileSystemCtx); ok {
+		return v.WalkCtx(ctx, u, fn)
+	}
+	return runCtxErr(ctx, func() error { return fs.Walk(u, fn) })
+}

--- a/vfs/context_test.go
+++ b/vfs/context_test.go
@@ -1,0 +1,183 @@
+package vfs
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// --- Fallback path (FS does NOT implement VFileSystemCtx) ---
+
+func TestOpenCtx_FallbackSucceeds(t *testing.T) {
+	fs := &fakeFS{}
+	_, err := OpenCtx(context.Background(), fs, mustURL(t, "file:///tmp/x"))
+	if err != nil {
+		t.Fatalf("OpenCtx: %v", err)
+	}
+	if !fs.openCalled {
+		t.Fatalf("fallback should have invoked fs.Open")
+	}
+}
+
+func TestOpenCtx_FallbackCancellation(t *testing.T) {
+	fs := &fakeFS{openDelay: 200 * time.Millisecond}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := OpenCtx(ctx, fs, mustURL(t, "file:///slow"))
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected ctx deadline error; got %v", err)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("OpenCtx didn't return promptly on cancel; took %v", elapsed)
+	}
+}
+
+func TestDeleteCtx_FallbackPropagatesError(t *testing.T) {
+	want := errors.New("nope")
+	fs := &fakeFS{deleteErr: want}
+	got := DeleteCtx(context.Background(), fs, mustURL(t, "file:///x"))
+	if !errors.Is(got, want) {
+		t.Fatalf("DeleteCtx err = %v, want %v", got, want)
+	}
+}
+
+// --- Delegated path (FS implements VFileSystemCtx) ---
+
+func TestOpenCtx_DelegatesToCtxImpl(t *testing.T) {
+	fs := &ctxFS{}
+	_, err := OpenCtx(context.Background(), fs, mustURL(t, "file:///x"))
+	if err != nil {
+		t.Fatalf("OpenCtx: %v", err)
+	}
+	if !fs.openCtxCalled {
+		t.Fatalf("expected OpenCtx to delegate to ctxFS.OpenCtx")
+	}
+}
+
+func TestAllHelpers_DelegateWhenAvailable(t *testing.T) {
+	fs := &ctxFS{}
+	ctx := context.Background()
+	u := mustURL(t, "file:///x")
+	_, _ = OpenCtx(ctx, fs, u)
+	_, _ = CreateCtx(ctx, fs, u)
+	_ = DeleteCtx(ctx, fs, u)
+	_, _ = ListCtx(ctx, fs, u)
+	_, _ = MkdirAllCtx(ctx, fs, u)
+	_ = CopyCtx(ctx, fs, u, u)
+	_ = MoveCtx(ctx, fs, u, u)
+	_ = WalkCtx(ctx, fs, u, func(VFile) error { return nil })
+
+	checks := []struct {
+		name string
+		hit  bool
+	}{
+		{"OpenCtx", fs.openCtxCalled},
+		{"CreateCtx", fs.createCtxCalled},
+		{"DeleteCtx", fs.deleteCtxCalled},
+		{"ListCtx", fs.listCtxCalled},
+		{"MkdirAllCtx", fs.mkdirAllCtxCalled},
+		{"CopyCtx", fs.copyCtxCalled},
+		{"MoveCtx", fs.moveCtxCalled},
+		{"WalkCtx", fs.walkCtxCalled},
+	}
+	for _, c := range checks {
+		if !c.hit {
+			t.Errorf("%s did not delegate to the VFileSystemCtx impl", c.name)
+		}
+	}
+}
+
+// --- Helpers ---
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u
+}
+
+// fakeFS implements VFileSystem (NOT VFileSystemCtx). Returned VFiles are
+// nil — these tests only assert call dispatch / cancellation timing, not
+// VFile behavior.
+type fakeFS struct {
+	openCalled bool
+	openDelay  time.Duration
+	deleteErr  error
+}
+
+func (f *fakeFS) Copy(src, dst *url.URL) error      { return nil }
+func (f *fakeFS) CopyRaw(src, dst string) error     { return nil }
+func (f *fakeFS) Create(u *url.URL) (VFile, error)  { return nil, nil }
+func (f *fakeFS) CreateRaw(string) (VFile, error)   { return nil, nil }
+func (f *fakeFS) Delete(*url.URL) error             { return f.deleteErr }
+func (f *fakeFS) DeleteRaw(string) error            { return f.deleteErr }
+func (f *fakeFS) List(*url.URL) ([]VFile, error)    { return nil, nil }
+func (f *fakeFS) ListRaw(string) ([]VFile, error)   { return nil, nil }
+func (f *fakeFS) Mkdir(*url.URL) (VFile, error)     { return nil, nil }
+func (f *fakeFS) MkdirRaw(string) (VFile, error)    { return nil, nil }
+func (f *fakeFS) MkdirAll(*url.URL) (VFile, error)  { return nil, nil }
+func (f *fakeFS) MkdirAllRaw(string) (VFile, error) { return nil, nil }
+func (f *fakeFS) Move(src, dst *url.URL) error      { return nil }
+func (f *fakeFS) MoveRaw(src, dst string) error     { return nil }
+func (f *fakeFS) Open(u *url.URL) (VFile, error) {
+	f.openCalled = true
+	if f.openDelay > 0 {
+		time.Sleep(f.openDelay)
+	}
+	return nil, nil
+}
+func (f *fakeFS) OpenRaw(string) (VFile, error)              { return nil, nil }
+func (f *fakeFS) Schemes() []string                          { return []string{"file"} }
+func (f *fakeFS) Walk(*url.URL, WalkFn) error                { return nil }
+func (f *fakeFS) Find(*url.URL, FileFilter) ([]VFile, error) { return nil, nil }
+func (f *fakeFS) WalkRaw(string, WalkFn) error               { return nil }
+func (f *fakeFS) DeleteMatching(*url.URL, FileFilter) error  { return nil }
+
+// ctxFS implements both VFileSystem and VFileSystemCtx; records which Ctx
+// methods were called so tests can assert delegation.
+type ctxFS struct {
+	fakeFS
+	openCtxCalled, createCtxCalled, deleteCtxCalled, listCtxCalled bool
+	mkdirAllCtxCalled, copyCtxCalled, moveCtxCalled, walkCtxCalled bool
+}
+
+func (c *ctxFS) OpenCtx(context.Context, *url.URL) (VFile, error) {
+	c.openCtxCalled = true
+	return nil, nil
+}
+func (c *ctxFS) CreateCtx(context.Context, *url.URL) (VFile, error) {
+	c.createCtxCalled = true
+	return nil, nil
+}
+func (c *ctxFS) DeleteCtx(context.Context, *url.URL) error {
+	c.deleteCtxCalled = true
+	return nil
+}
+func (c *ctxFS) ListCtx(context.Context, *url.URL) ([]VFile, error) {
+	c.listCtxCalled = true
+	return nil, nil
+}
+func (c *ctxFS) MkdirAllCtx(context.Context, *url.URL) (VFile, error) {
+	c.mkdirAllCtxCalled = true
+	return nil, nil
+}
+func (c *ctxFS) CopyCtx(context.Context, *url.URL, *url.URL) error {
+	c.copyCtxCalled = true
+	return nil
+}
+func (c *ctxFS) MoveCtx(context.Context, *url.URL, *url.URL) error {
+	c.moveCtxCalled = true
+	return nil
+}
+func (c *ctxFS) WalkCtx(context.Context, *url.URL, WalkFn) error {
+	c.walkCtxCalled = true
+	return nil
+}

--- a/vfs/doc.go
+++ b/vfs/doc.go
@@ -1,2 +1,57 @@
-// package vfs provides a set of utilities for working with virtual file systems in Go.
+// Package vfs provides a URL-addressed, scheme-pluggable virtual filesystem
+// abstraction with first-class support for cloud object stores.
+//
+// # Overview
+//
+// The package centers on three small interfaces:
+//
+//   - VFileSystem — operations: Open / Create / Delete / List / Walk / ...
+//   - VFile       — a file handle: io.ReadWriteSeeker + Info + Delete + ...
+//   - VFileInfo   — metadata: extends io/fs.FileInfo
+//
+// Backends register themselves with the package-level Manager by URL
+// scheme; callers use URLs (or strings via the *Raw variants) and the
+// Manager dispatches. Local FS ships in-tree (oss.nandlabs.io/golly/vfs);
+// S3 lives in oss.nandlabs.io/golly-aws/s3; GCS in
+// oss.nandlabs.io/golly-gcp/gs.
+//
+// # Optional capability interfaces
+//
+// Several capabilities are exposed as optional interfaces that backends
+// opt in to. Callers use the package-level helpers, which delegate when
+// the backend implements the capability and fall back to best-effort
+// emulation otherwise:
+//
+//   - VFileSystemCtx — context.Context-aware variants of the heavy I/O
+//     operations. Helpers: vfs.OpenCtx, CreateCtx, DeleteCtx, ListCtx,
+//     MkdirAllCtx, CopyCtx, MoveCtx, WalkCtx.
+//   - Lister         — paginated, cancellable listing. Helper:
+//     vfs.ListIter.
+//   - RangeReader    — HTTP-Range-style partial reads on a VFile.
+//     Helper: vfs.ReadRange.
+//
+// Sentinel errors (vfs.ErrNotExist, ErrPermission, ErrNotSupported,
+// ErrIsDir, ErrNotDir, ErrClosed) wrap io/fs equivalents where possible
+// so errors.Is(err, fs.ErrNotExist) keeps working across backends.
+//
+// # Convenience helpers
+//
+//   - vfs.ReadAllString(f), vfs.ReadAllBytes(f) — replace the deprecated
+//     VFile.AsString / AsBytes methods.
+//   - vfs.Exists(fs, u) / vfs.ExistsCtx(ctx, fs, u) — existence check
+//     that handles the open-then-Info pattern most backends need.
+//
+// # Concurrency
+//
+// A VFile is NOT safe for concurrent use; the read/write cursor is
+// single-state. Open separate handles per goroutine. The VFileSystem
+// itself IS safe for concurrent use across all in-tree implementations
+// (caveats noted on individual backends).
+//
+// # Roadmap (v2)
+//
+// The current interface duplicates every method as Foo(*url.URL) and
+// FooRaw(string). A future major version (v2) will collapse this — the
+// URL form is the canonical one; the Raw form is convenience that can
+// move to free helpers. Prefer the URL-typed methods in new code.
 package vfs

--- a/vfs/errors.go
+++ b/vfs/errors.go
@@ -1,0 +1,43 @@
+package vfs
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+)
+
+// Sentinel errors that VFileSystem implementations should return (or wrap
+// via fmt.Errorf with %w) so callers can switch on outcomes with
+// errors.Is across backends.
+//
+// Where the meaning of the underlying error overlaps with io/fs, the
+// sentinel is wrapped around io/fs.ErrNotExist / fs.ErrPermission so
+// errors.Is(err, fs.ErrNotExist) also returns true. Code that checks
+// stdlib sentinels keeps working.
+var (
+	// ErrNotExist is returned when a file or directory does not exist
+	// at the given URL.
+	ErrNotExist = fmt.Errorf("vfs: file does not exist: %w", fs.ErrNotExist)
+
+	// ErrPermission is returned when the caller lacks the permission
+	// required for the operation.
+	ErrPermission = fmt.Errorf("vfs: permission denied: %w", fs.ErrPermission)
+
+	// ErrNotSupported is returned by backends that do not implement an
+	// optional capability (e.g. ranged reads against a backend that
+	// only supports streaming) or by package-level helpers when a
+	// backend does not satisfy the required optional interface.
+	ErrNotSupported = errors.New("vfs: operation not supported")
+
+	// ErrIsDir is returned when an operation that requires a regular
+	// file is invoked on a directory.
+	ErrIsDir = errors.New("vfs: is a directory")
+
+	// ErrNotDir is returned when an operation that requires a directory
+	// is invoked on a regular file.
+	ErrNotDir = errors.New("vfs: not a directory")
+
+	// ErrClosed is returned by VFile methods after Close() has been
+	// called.
+	ErrClosed = errors.New("vfs: closed")
+)

--- a/vfs/helpers.go
+++ b/vfs/helpers.go
@@ -1,0 +1,83 @@
+package vfs
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"net/url"
+)
+
+// ReadAllString reads the entire content of f into a string.
+//
+// Use deliberately: for large files this loads everything into memory
+// and is the streaming-safe equivalent of VFile.AsString() which is
+// deprecated. Prefer io.Copy / io.CopyBuffer when the caller can write
+// directly to a sink.
+//
+// The file's read position is advanced to EOF. The caller is responsible
+// for Close.
+func ReadAllString(f VFile) (string, error) {
+	b, err := ReadAllBytes(f)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// ReadAllBytes reads the entire content of f into a byte slice.
+//
+// Use deliberately: for large files this loads everything into memory
+// and is the streaming-safe equivalent of VFile.AsBytes() which is
+// deprecated. Prefer io.Copy / io.CopyBuffer for streaming flows.
+//
+// The file's read position is advanced to EOF. The caller is responsible
+// for Close.
+func ReadAllBytes(f VFile) ([]byte, error) {
+	if f == nil {
+		return nil, errors.New("vfs: nil VFile")
+	}
+	return io.ReadAll(f)
+}
+
+// Exists reports whether the given URL resolves to a real file or
+// directory on the supplied filesystem.
+//
+// (true, nil)  — the entity exists
+// (false, nil) — the entity does not exist (errors.Is(err, fs.ErrNotExist))
+// (false, err) — some other error was encountered (permission, network…);
+//
+//	the returned err is wrapped, callers may errors.Is it
+//	against the vfs sentinels.
+func Exists(fs VFileSystem, u *url.URL) (bool, error) {
+	return ExistsCtx(context.Background(), fs, u)
+}
+
+// ExistsCtx is the context-aware variant of Exists. If the underlying
+// filesystem implements VFileSystemCtx, OpenCtx is used; otherwise the
+// helper falls back to the non-ctx Open via runCtx.
+func ExistsCtx(ctx context.Context, sys VFileSystem, u *url.URL) (bool, error) {
+	if sys == nil {
+		return false, errors.New("vfs: nil VFileSystem")
+	}
+	f, err := OpenCtx(ctx, sys, u)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	// Many backends (S3, GCS) construct a handle eagerly without
+	// checking existence — Open succeeds even for missing keys. A
+	// follow-up Info() is what actually probes existence on most
+	// implementations.
+	_, infoErr := f.Info()
+	_ = f.Close()
+	if infoErr != nil {
+		if errors.Is(infoErr, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, infoErr
+	}
+	return true, nil
+}

--- a/vfs/helpers_test.go
+++ b/vfs/helpers_test.go
@@ -1,0 +1,196 @@
+package vfs
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/fs"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestReadAllBytes_StreamsViaReader(t *testing.T) {
+	f := &readableFakeFile{content: []byte("hello world")}
+	got, err := ReadAllBytes(f)
+	if err != nil {
+		t.Fatalf("ReadAllBytes: %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("got %q, want %q", got, "hello world")
+	}
+}
+
+func TestReadAllString_StreamsViaReader(t *testing.T) {
+	f := &readableFakeFile{content: []byte("text content")}
+	got, err := ReadAllString(f)
+	if err != nil {
+		t.Fatalf("ReadAllString: %v", err)
+	}
+	if got != "text content" {
+		t.Errorf("got %q, want %q", got, "text content")
+	}
+}
+
+func TestReadAllBytes_NilFile(t *testing.T) {
+	if _, err := ReadAllBytes(nil); err == nil {
+		t.Fatal("expected error for nil VFile")
+	}
+}
+
+func TestSentinelErrors_WrapStdlib(t *testing.T) {
+	if !errors.Is(ErrNotExist, fs.ErrNotExist) {
+		t.Error("ErrNotExist should wrap fs.ErrNotExist")
+	}
+	if !errors.Is(ErrPermission, fs.ErrPermission) {
+		t.Error("ErrPermission should wrap fs.ErrPermission")
+	}
+}
+
+func TestExistsCtx_DispatchesToInfo(t *testing.T) {
+	fs := &existsFakeFS{info: &fakeInfo{name: "x"}}
+	ok, err := ExistsCtx(context.Background(), fs, mustURLForExists(t, "file:///x"))
+	if err != nil {
+		t.Fatalf("ExistsCtx: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok=true, fakeFS returned a valid Info")
+	}
+}
+
+func TestExistsCtx_NotExistReturnsFalseNoError(t *testing.T) {
+	missing := errors.Join(ErrNotExist) // wraps fs.ErrNotExist via sentinel
+	fs := &existsFakeFS{infoErr: missing}
+	ok, err := ExistsCtx(context.Background(), fs, mustURLForExists(t, "file:///missing"))
+	if err != nil {
+		t.Fatalf("ExistsCtx should swallow not-exist; got err=%v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false for missing file")
+	}
+}
+
+func TestExistsCtx_OpenError(t *testing.T) {
+	fs := &existsFakeFS{openErr: errors.New("network down")}
+	ok, err := ExistsCtx(context.Background(), fs, mustURLForExists(t, "file:///x"))
+	if err == nil {
+		t.Fatalf("expected error to bubble up")
+	}
+	if ok {
+		t.Fatalf("ok must be false on error")
+	}
+}
+
+func TestExistsCtx_NilFS(t *testing.T) {
+	if _, err := ExistsCtx(context.Background(), nil, &url.URL{}); err == nil {
+		t.Fatal("expected error for nil fs")
+	}
+}
+
+// --- helpers ---
+
+func mustURLForExists(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u
+}
+
+// readableFakeFile satisfies VFile minimally for ReadAllBytes /
+// ReadAllString tests — only Read is exercised, the rest are nil-ish.
+type readableFakeFile struct {
+	content []byte
+	pos     int
+}
+
+func (f *readableFakeFile) Read(p []byte) (int, error) {
+	if f.pos >= len(f.content) {
+		return 0, io.EOF
+	}
+	n := copy(p, f.content[f.pos:])
+	f.pos += n
+	return n, nil
+}
+func (f *readableFakeFile) Write([]byte) (int, error)          { return 0, nil }
+func (f *readableFakeFile) Seek(int64, int) (int64, error)     { return 0, nil }
+func (f *readableFakeFile) Close() error                       { return nil }
+func (f *readableFakeFile) AsString() (string, error)          { return string(f.content), nil }
+func (f *readableFakeFile) AsBytes() ([]byte, error)           { return f.content, nil }
+func (f *readableFakeFile) WriteString(string) (int, error)    { return 0, nil }
+func (f *readableFakeFile) ContentType() string                { return "" }
+func (f *readableFakeFile) ListAll() ([]VFile, error)          { return nil, nil }
+func (f *readableFakeFile) Delete() error                      { return nil }
+func (f *readableFakeFile) DeleteAll() error                   { return nil }
+func (f *readableFakeFile) Info() (VFileInfo, error)           { return nil, nil }
+func (f *readableFakeFile) Parent() (VFile, error)             { return nil, nil }
+func (f *readableFakeFile) Url() *url.URL                      { return &url.URL{} }
+func (f *readableFakeFile) AddProperty(string, string) error   { return nil }
+func (f *readableFakeFile) GetProperty(string) (string, error) { return "", nil }
+
+// existsFakeFS exercises ExistsCtx without needing a real backend.
+type existsFakeFS struct {
+	openErr error
+	info    VFileInfo
+	infoErr error
+}
+
+func (e *existsFakeFS) Open(*url.URL) (VFile, error) {
+	if e.openErr != nil {
+		return nil, e.openErr
+	}
+	return &infoFakeFile{info: e.info, err: e.infoErr}, nil
+}
+func (e *existsFakeFS) Copy(src, dst *url.URL) error               { return nil }
+func (e *existsFakeFS) CopyRaw(src, dst string) error              { return nil }
+func (e *existsFakeFS) Create(*url.URL) (VFile, error)             { return nil, nil }
+func (e *existsFakeFS) CreateRaw(string) (VFile, error)            { return nil, nil }
+func (e *existsFakeFS) Delete(*url.URL) error                      { return nil }
+func (e *existsFakeFS) DeleteRaw(string) error                     { return nil }
+func (e *existsFakeFS) List(*url.URL) ([]VFile, error)             { return nil, nil }
+func (e *existsFakeFS) ListRaw(string) ([]VFile, error)            { return nil, nil }
+func (e *existsFakeFS) Mkdir(*url.URL) (VFile, error)              { return nil, nil }
+func (e *existsFakeFS) MkdirRaw(string) (VFile, error)             { return nil, nil }
+func (e *existsFakeFS) MkdirAll(*url.URL) (VFile, error)           { return nil, nil }
+func (e *existsFakeFS) MkdirAllRaw(string) (VFile, error)          { return nil, nil }
+func (e *existsFakeFS) Move(src, dst *url.URL) error               { return nil }
+func (e *existsFakeFS) MoveRaw(src, dst string) error              { return nil }
+func (e *existsFakeFS) OpenRaw(string) (VFile, error)              { return nil, nil }
+func (e *existsFakeFS) Schemes() []string                          { return []string{"file"} }
+func (e *existsFakeFS) Walk(*url.URL, WalkFn) error                { return nil }
+func (e *existsFakeFS) Find(*url.URL, FileFilter) ([]VFile, error) { return nil, nil }
+func (e *existsFakeFS) WalkRaw(string, WalkFn) error               { return nil }
+func (e *existsFakeFS) DeleteMatching(*url.URL, FileFilter) error  { return nil }
+
+// infoFakeFile only meaningfully implements Info; reads/writes/etc. are nil.
+type infoFakeFile struct {
+	info VFileInfo
+	err  error
+}
+
+func (i *infoFakeFile) Read([]byte) (int, error)           { return 0, io.EOF }
+func (i *infoFakeFile) Write([]byte) (int, error)          { return 0, nil }
+func (i *infoFakeFile) Seek(int64, int) (int64, error)     { return 0, nil }
+func (i *infoFakeFile) Close() error                       { return nil }
+func (i *infoFakeFile) AsString() (string, error)          { return "", nil }
+func (i *infoFakeFile) AsBytes() ([]byte, error)           { return nil, nil }
+func (i *infoFakeFile) WriteString(string) (int, error)    { return 0, nil }
+func (i *infoFakeFile) ContentType() string                { return "" }
+func (i *infoFakeFile) ListAll() ([]VFile, error)          { return nil, nil }
+func (i *infoFakeFile) Delete() error                      { return nil }
+func (i *infoFakeFile) DeleteAll() error                   { return nil }
+func (i *infoFakeFile) Info() (VFileInfo, error)           { return i.info, i.err }
+func (i *infoFakeFile) Parent() (VFile, error)             { return nil, nil }
+func (i *infoFakeFile) Url() *url.URL                      { return &url.URL{} }
+func (i *infoFakeFile) AddProperty(string, string) error   { return nil }
+func (i *infoFakeFile) GetProperty(string) (string, error) { return "", nil }
+
+type fakeInfo struct{ name string }
+
+func (f *fakeInfo) Name() string       { return f.name }
+func (f *fakeInfo) Size() int64        { return 0 }
+func (f *fakeInfo) Mode() fs.FileMode  { return 0 }
+func (f *fakeInfo) ModTime() time.Time { return time.Time{} }
+func (f *fakeInfo) IsDir() bool        { return false }
+func (f *fakeInfo) Sys() any           { return nil }

--- a/vfs/listing.go
+++ b/vfs/listing.go
@@ -1,0 +1,99 @@
+package vfs
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+)
+
+// ErrSkipDir is returned by a WalkFn callback to skip the rest of the
+// current directory's contents without aborting the walk. Walk
+// implementations that honor the sentinel SHOULD continue with the
+// next sibling. Mirrors io/fs.SkipDir for consumer convenience.
+var ErrSkipDir = errors.New("vfs: skip directory")
+
+// ErrSkipAll is returned by a WalkFn callback to terminate the walk
+// cleanly without surfacing as an error from Walk / WalkCtx. Walk
+// implementations that honor the sentinel SHOULD treat it as success
+// and stop iterating. Mirrors io/fs.SkipAll for consumer convenience.
+var ErrSkipAll = errors.New("vfs: skip all")
+
+// FileIterator yields VFiles one at a time without materializing the
+// whole result set. Returned by Lister.ListIter — call Next until it
+// returns io.EOF, then Close to release backend resources.
+//
+// FileIterator is NOT safe for concurrent use; one goroutine should
+// own a given iterator.
+type FileIterator interface {
+	// Next returns the next VFile or io.EOF when no more remain.
+	// Returns ctx.Err() if the context is canceled mid-iteration.
+	Next(ctx context.Context) (VFile, error)
+	// Close releases backend resources (HTTP connections, paging
+	// state, etc.). Idempotent. Safe to call without consuming the
+	// iterator to completion.
+	Close() error
+}
+
+// Lister is an optional capability a VFileSystem may implement to
+// support paginated, cancellable listing of large directories /
+// prefixes. Backends without it fall back to the eager List() return
+// in vfs.ListIter (the package helper).
+//
+// Cloud backends listing object stores (S3, GCS) SHOULD implement
+// Lister so callers don't materialize million-key prefixes into one
+// slice.
+type Lister interface {
+	ListIter(ctx context.Context, u *url.URL) (FileIterator, error)
+}
+
+// ListIter returns a paginated iterator over the entries at u. If fs
+// implements Lister it is used; otherwise the helper falls back to the
+// eager List() result wrapped as a slice-backed iterator.
+//
+// Always Close the returned iterator (even on early break) to release
+// backend resources.
+func ListIter(ctx context.Context, sys VFileSystem, u *url.URL) (FileIterator, error) {
+	if l, ok := sys.(Lister); ok {
+		return l.ListIter(ctx, u)
+	}
+	files, err := sys.List(u)
+	if err != nil {
+		return nil, err
+	}
+	return &sliceIterator{files: files}, nil
+}
+
+// sliceIterator wraps a fully-materialized []VFile as a FileIterator so
+// the fallback path of ListIter has the same signature as a real
+// paginated iterator.
+type sliceIterator struct {
+	files []VFile
+	idx   int
+	done  bool
+}
+
+// Next returns the next VFile in the slice or io.EOF when exhausted.
+// Honors ctx cancellation between elements (cheap; the work is already
+// done up-front).
+func (s *sliceIterator) Next(ctx context.Context) (VFile, error) {
+	if s.done {
+		return nil, io.EOF
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if s.idx >= len(s.files) {
+		s.done = true
+		return nil, io.EOF
+	}
+	f := s.files[s.idx]
+	s.idx++
+	return f, nil
+}
+
+// Close marks the iterator finished. Idempotent.
+func (s *sliceIterator) Close() error {
+	s.done = true
+	return nil
+}

--- a/vfs/listing_test.go
+++ b/vfs/listing_test.go
@@ -1,0 +1,131 @@
+package vfs
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"testing"
+)
+
+func TestListIter_FallbackOverEagerList(t *testing.T) {
+	want := []VFile{&readableFakeFile{content: []byte("a")}, &readableFakeFile{content: []byte("b")}}
+	fs := &listFakeFS{eager: want}
+	it, err := ListIter(context.Background(), fs, mustURLForList(t, "file:///dir"))
+	if err != nil {
+		t.Fatalf("ListIter: %v", err)
+	}
+	defer it.Close()
+
+	count := 0
+	for {
+		_, err := it.Next(context.Background())
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+		count++
+	}
+	if count != len(want) {
+		t.Fatalf("got %d items, want %d", count, len(want))
+	}
+}
+
+func TestListIter_DelegatesToListerWhenAvailable(t *testing.T) {
+	called := false
+	fs := &listerFakeFS{
+		hook: func(context.Context, *url.URL) (FileIterator, error) {
+			called = true
+			return &sliceIterator{}, nil
+		},
+	}
+	_, err := ListIter(context.Background(), fs, mustURLForList(t, "file:///dir"))
+	if err != nil {
+		t.Fatalf("ListIter: %v", err)
+	}
+	if !called {
+		t.Fatalf("expected Lister.ListIter to be called")
+	}
+}
+
+func TestSliceIterator_RespectsCtxCancellation(t *testing.T) {
+	it := &sliceIterator{files: []VFile{&readableFakeFile{}, &readableFakeFile{}}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := it.Next(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected ctx.Canceled, got %v", err)
+	}
+}
+
+func TestSliceIterator_CloseIsIdempotent(t *testing.T) {
+	it := &sliceIterator{files: []VFile{&readableFakeFile{}}}
+	if err := it.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if _, err := it.Next(context.Background()); err != io.EOF {
+		t.Fatalf("Next after Close should be EOF; got %v", err)
+	}
+}
+
+func TestWalkSkipSentinels_Defined(t *testing.T) {
+	if ErrSkipDir == nil || ErrSkipAll == nil {
+		t.Fatal("ErrSkipDir and ErrSkipAll must be non-nil")
+	}
+	if ErrSkipDir == ErrSkipAll {
+		t.Fatal("ErrSkipDir and ErrSkipAll must be distinct sentinels")
+	}
+}
+
+// --- helpers ---
+
+func mustURLForList(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %q: %v", raw, err)
+	}
+	return u
+}
+
+// listFakeFS satisfies VFileSystem but NOT Lister — exercises the eager
+// List fallback path.
+type listFakeFS struct {
+	eager []VFile
+}
+
+func (f *listFakeFS) Copy(src, dst *url.URL) error               { return nil }
+func (f *listFakeFS) CopyRaw(src, dst string) error              { return nil }
+func (f *listFakeFS) Create(*url.URL) (VFile, error)             { return nil, nil }
+func (f *listFakeFS) CreateRaw(string) (VFile, error)            { return nil, nil }
+func (f *listFakeFS) Delete(*url.URL) error                      { return nil }
+func (f *listFakeFS) DeleteRaw(string) error                     { return nil }
+func (f *listFakeFS) List(*url.URL) ([]VFile, error)             { return f.eager, nil }
+func (f *listFakeFS) ListRaw(string) ([]VFile, error)            { return f.eager, nil }
+func (f *listFakeFS) Mkdir(*url.URL) (VFile, error)              { return nil, nil }
+func (f *listFakeFS) MkdirRaw(string) (VFile, error)             { return nil, nil }
+func (f *listFakeFS) MkdirAll(*url.URL) (VFile, error)           { return nil, nil }
+func (f *listFakeFS) MkdirAllRaw(string) (VFile, error)          { return nil, nil }
+func (f *listFakeFS) Move(src, dst *url.URL) error               { return nil }
+func (f *listFakeFS) MoveRaw(src, dst string) error              { return nil }
+func (f *listFakeFS) Open(*url.URL) (VFile, error)               { return nil, nil }
+func (f *listFakeFS) OpenRaw(string) (VFile, error)              { return nil, nil }
+func (f *listFakeFS) Schemes() []string                          { return []string{"file"} }
+func (f *listFakeFS) Walk(*url.URL, WalkFn) error                { return nil }
+func (f *listFakeFS) Find(*url.URL, FileFilter) ([]VFile, error) { return nil, nil }
+func (f *listFakeFS) WalkRaw(string, WalkFn) error               { return nil }
+func (f *listFakeFS) DeleteMatching(*url.URL, FileFilter) error  { return nil }
+
+// listerFakeFS satisfies both VFileSystem and Lister.
+type listerFakeFS struct {
+	listFakeFS
+	hook func(context.Context, *url.URL) (FileIterator, error)
+}
+
+func (f *listerFakeFS) ListIter(ctx context.Context, u *url.URL) (FileIterator, error) {
+	return f.hook(ctx, u)
+}

--- a/vfs/range.go
+++ b/vfs/range.go
@@ -1,0 +1,63 @@
+package vfs
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+// RangeReader is an optional capability a VFile may implement to expose
+// HTTP-Range-style partial reads. Cloud backends (S3, GCS) SHOULD
+// implement it and map ReadRange to a native ranged GET so callers can
+// fetch a small window of a large object cheaply (file headers, media
+// byte ranges, resumable downloads).
+//
+// Local-filesystem implementations gain little — Seek+Read is the same
+// operation under the hood — but may implement it for consistency.
+type RangeReader interface {
+	// ReadRange returns up to length bytes starting at offset off.
+	// A length of 0 means "read to EOF from off". Returns (nil, io.EOF)
+	// when off is past the end. Implementations should not perform a
+	// full-object download to satisfy a small range.
+	ReadRange(ctx context.Context, off, length int64) ([]byte, error)
+}
+
+// ReadRange returns a slice of f's content [off, off+length). If f
+// implements RangeReader the call is delegated; otherwise the helper
+// falls back to Seek+Read, which on cloud backends may perform a
+// full-object download.
+//
+// length == 0 means "read to EOF from off".
+//
+// Returns ErrNotSupported if f does not implement RangeReader AND the
+// fallback (Seek + Read) is unavailable because f does not support
+// io.Seeker. Returns io.EOF when off is past the end.
+func ReadRange(ctx context.Context, f VFile, off, length int64) ([]byte, error) {
+	if f == nil {
+		return nil, errors.New("vfs: nil VFile")
+	}
+	if rr, ok := f.(RangeReader); ok {
+		return rr.ReadRange(ctx, off, length)
+	}
+	// Fallback: seek + read. This may pull the whole object on cloud
+	// backends that don't implement Seek natively, so this path is
+	// best-effort and documented as such.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if _, err := f.Seek(off, io.SeekStart); err != nil {
+		return nil, err
+	}
+	if length <= 0 {
+		return io.ReadAll(f)
+	}
+	buf := make([]byte, length)
+	n, err := io.ReadFull(f, buf)
+	if err == io.ErrUnexpectedEOF {
+		return buf[:n], nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/vfs/range_test.go
+++ b/vfs/range_test.go
@@ -1,0 +1,118 @@
+package vfs
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/url"
+	"testing"
+)
+
+func TestReadRange_DelegatesToRangeReader(t *testing.T) {
+	rr := &rangeReaderFake{want: []byte("partial")}
+	got, err := ReadRange(context.Background(), rr, 10, 7)
+	if err != nil {
+		t.Fatalf("ReadRange: %v", err)
+	}
+	if string(got) != "partial" {
+		t.Errorf("got %q, want %q", got, "partial")
+	}
+	if rr.lastOff != 10 || rr.lastLen != 7 {
+		t.Errorf("off/len passthrough wrong: off=%d len=%d", rr.lastOff, rr.lastLen)
+	}
+}
+
+func TestReadRange_FallbackSeekRead(t *testing.T) {
+	// readableFakeFile implements Seek (returns 0,0,nil — accepts any offset)
+	// and Read. ReadRange should drive both.
+	f := &seekableFake{content: []byte("abcdefghij")}
+	got, err := ReadRange(context.Background(), f, 3, 4)
+	if err != nil {
+		t.Fatalf("ReadRange fallback: %v", err)
+	}
+	if string(got) != "defg" {
+		t.Errorf("got %q, want %q", got, "defg")
+	}
+}
+
+func TestReadRange_FallbackZeroLengthReadsToEOF(t *testing.T) {
+	f := &seekableFake{content: []byte("xyz")}
+	got, err := ReadRange(context.Background(), f, 1, 0)
+	if err != nil {
+		t.Fatalf("ReadRange: %v", err)
+	}
+	if string(got) != "yz" {
+		t.Errorf("got %q, want %q", got, "yz")
+	}
+}
+
+func TestReadRange_NilFile(t *testing.T) {
+	if _, err := ReadRange(context.Background(), nil, 0, 1); err == nil {
+		t.Fatal("expected error for nil VFile")
+	}
+}
+
+func TestReadRange_CtxCancelledBeforeFallback(t *testing.T) {
+	f := &seekableFake{content: []byte("abc")}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := ReadRange(ctx, f, 0, 1); !errors.Is(err, context.Canceled) {
+		t.Errorf("expected ctx.Canceled, got %v", err)
+	}
+}
+
+// --- helpers ---
+
+// rangeReaderFake implements both VFile and RangeReader; only ReadRange is
+// exercised by the range tests.
+type rangeReaderFake struct {
+	readableFakeFile
+	want    []byte
+	lastOff int64
+	lastLen int64
+}
+
+func (r *rangeReaderFake) ReadRange(_ context.Context, off, length int64) ([]byte, error) {
+	r.lastOff, r.lastLen = off, length
+	return r.want, nil
+}
+
+// seekableFake supports a proper Seek + Read pair for the fallback path.
+type seekableFake struct {
+	content []byte
+	pos     int64
+}
+
+func (s *seekableFake) Read(p []byte) (int, error) {
+	if s.pos >= int64(len(s.content)) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.content[s.pos:])
+	s.pos += int64(n)
+	return n, nil
+}
+func (s *seekableFake) Write([]byte) (int, error) { return 0, nil }
+func (s *seekableFake) Seek(off int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		s.pos = off
+	case io.SeekCurrent:
+		s.pos += off
+	case io.SeekEnd:
+		s.pos = int64(len(s.content)) + off
+	}
+	return s.pos, nil
+}
+func (s *seekableFake) Close() error                       { return nil }
+func (s *seekableFake) AsString() (string, error)          { return string(s.content), nil }
+func (s *seekableFake) AsBytes() ([]byte, error)           { return s.content, nil }
+func (s *seekableFake) WriteString(string) (int, error)    { return 0, nil }
+func (s *seekableFake) ContentType() string                { return "" }
+func (s *seekableFake) ListAll() ([]VFile, error)          { return nil, nil }
+func (s *seekableFake) Delete() error                      { return nil }
+func (s *seekableFake) DeleteAll() error                   { return nil }
+func (s *seekableFake) Info() (VFileInfo, error)           { return nil, nil }
+func (s *seekableFake) Parent() (VFile, error)             { return nil, nil }
+func (s *seekableFake) Url() *url.URL                      { return &url.URL{} }
+func (s *seekableFake) AddProperty(string, string) error   { return nil }
+func (s *seekableFake) GetProperty(string) (string, error) { return "", nil }

--- a/vfs/vfile.go
+++ b/vfs/vfile.go
@@ -8,7 +8,25 @@ import (
 
 type FileFilter func(file VFile) (bool, error)
 
-// VFile interface provides the basic functions required to interact
+// VFile is a handle to a single file (or directory) in a VFileSystem.
+//
+// Concurrency: a VFile is NOT safe for concurrent use. The
+// embedded io.Reader / io.Writer / io.Seeker share a single cursor,
+// and the property bag (see AddProperty) is not synchronized. Open one
+// handle per goroutine or wrap with your own mutex.
+//
+// Lifecycle: callers MUST Close the handle. Behavior of subsequent
+// method calls after Close is implementation-defined; well-behaved
+// backends return vfs.ErrClosed.
+//
+// Property bag (AddProperty / GetProperty): semantics are backend-
+// defined and intentionally narrow. The local-filesystem backend
+// stores properties in process memory only and DOES NOT persist them
+// across process restarts. Cloud backends MAY map properties to
+// native object metadata (S3 x-amz-meta-*, GCS metadata, Azure
+// metadata) — see each backend's package docs for constraints (key
+// charsets, total size limits) and persistence guarantees. Do not
+// rely on properties as a primary metadata store across backends.
 type VFile interface {
 	// Closer interface included from io package
 	io.Closer
@@ -26,20 +44,43 @@ type VFile interface {
 	Parent() (VFile, error)
 	// Url of the file
 	Url() *url.URL
-	// AddProperty will add a property to the file
+	// AddProperty associates a name/value pair with the file. See the
+	// VFile godoc for the per-backend persistence contract — local FS
+	// keeps properties only in-process; cloud backends may map them to
+	// native object metadata with their own constraints.
 	AddProperty(name string, value string) error
-	// GetProperty will add a property to the file
+	// GetProperty retrieves a previously-set property value. Returns
+	// ("", nil) when the property is unset; see VFile godoc for
+	// per-backend persistence semantics.
 	GetProperty(name string) (string, error)
 }
 
-// VFileContent interface providers access to the content
+// VFileContent provides streaming access to a file's content via the
+// io.Reader / io.Writer / io.Seeker primitives.
+//
+// Prefer the streaming methods for any work that scales with file
+// size. AsString / AsBytes load the entire file into memory and are
+// kept only as a backwards-compatible convenience; see their
+// deprecation notes below for replacements.
 type VFileContent interface {
 	io.ReadWriteSeeker
-	// AsString content of the file. This should be used very carefully as it is not wise to load a large file in to string
+
+	// AsString reads the file's entire content into a string.
+	//
+	// Deprecated: use vfs.ReadAllString(f) instead. This method
+	// will be removed in a future major version. Loading large
+	// cloud objects (S3, GCS, Azure) via this path can OOM the
+	// process — prefer io.Copy / io.ReadAll directly when the
+	// size is unknown.
 	AsString() (string, error)
-	// AsBytes content of the file.This should be used very carefully as it is not wise to load a large file into an array
+
+	// AsBytes reads the file's entire content into a byte slice.
+	//
+	// Deprecated: use vfs.ReadAllBytes(f) instead. Same OOM
+	// caveats as AsString.
 	AsBytes() ([]byte, error)
-	// WriteString method with write the string
+
+	// WriteString writes s to the underlying writer.
 	WriteString(s string) (int, error)
 	// ContentType of the underlying content. If not set defaults to UTF-8 for text files
 	ContentType() string


### PR DESCRIPTION
## Description

Implements the optional context-aware capability for `vfs.VFileSystem` PLUS the additional critique points beyond #1 (context) that were raised in a separate review of the vfs package. Closes #104; addresses the seven remaining critique points (#2-#8) — #2 (Raw collapse) deferred to v2 with a doc note since it's genuinely breaking.

### Related Issue

Closes #104.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation update (#6 property-bag semantics, #7 concurrency contract, v2 roadmap)
- [ ] 🔧 Refactoring
- [x] ✅ Test update
- [ ] 🔨 Build / CI changes

## Critique-driven changes

| # | Point | Done in this PR |
|---|------|------------------|
| #1 | No `context.Context` anywhere | ✅ `VFileSystemCtx` optional interface + 8 dispatcher helpers (`OpenCtx`, `CopyCtx`, …) with delegation + cancellation-aware fallback |
| #2 | `Raw` / non-`Raw` duplication | ⏳ Deferred to v2 (doc note in `doc.go`) — collapsing is genuinely breaking |
| #3 | `AsString`/`AsBytes` invite OOM | ✅ Free helpers `vfs.ReadAllString(f)` / `vfs.ReadAllBytes(f)`; interface methods marked **Deprecated** with godoc pointers |
| #4 | Eager `List`/`Find`/`Walk` won't scale | ✅ New `Lister` optional interface + `FileIterator` + `vfs.ListIter` helper with eager-list fallback. New `vfs.ErrSkipDir` / `vfs.ErrSkipAll` sentinels for `WalkFn` |
| #5 | No range reads / partial fetch | ✅ New `RangeReader` optional VFile capability + `vfs.ReadRange(ctx, f, off, length)` helper. Falls back to Seek+Read |
| #6 | Property bag semantics undocumented | ✅ `VFile.AddProperty`/`GetProperty` godoc clarified: local FS = in-memory; cloud backends MAY map to native metadata with their own constraints |
| #7 | Concurrency contract unstated | ✅ `VFile` godoc: NOT safe for concurrent use (single-cursor read/write/seek; property bag unsynced) |
| #8 | Error semantics not standardised | ✅ `ErrNotExist`/`ErrPermission` wrap `io/fs.ErrNotExist`/`ErrPermission` for `errors.Is`; `ErrNotSupported`, `ErrIsDir`, `ErrNotDir`, `ErrClosed`. `vfs.Exists` / `ExistsCtx` helpers |

## New files

- `vfs/errors.go` — sentinel set
- `vfs/helpers.go` — `ReadAllString`, `ReadAllBytes`, `Exists`, `ExistsCtx`
- `vfs/listing.go` — `Lister`, `FileIterator`, `ErrSkipDir`/`ErrSkipAll`, `ListIter`, internal `sliceIterator`
- `vfs/range.go` — `RangeReader`, `ReadRange`
- `vfs/{context,helpers,listing,range}_test.go` — full coverage

## Testing

- [x] All existing tests pass
- [x] New tests added for every new public surface

```
$ go test -race ./... | grep -c ^ok
36
$ go test -race ./... | grep -c ^FAIL
0

$ golangci-lint run
0 issues.
```

15 new race-clean tests in vfs:

- ReadAllBytes/String streaming + nil-file error
- Sentinel errors wrap io/fs counterparts
- ExistsCtx dispatches / swallows not-exist / propagates other errors
- ListIter delegates / falls back to eager List
- sliceIterator Next + ctx cancel + idempotent Close
- ErrSkipDir/All defined and distinct
- ReadRange delegates / falls back via Seek+Read / handles zero length / ctx-cancelled

## Checklist

- [x] Code follows the project's style and conventions
- [x] Self-reviewed
- [x] Comments on hard-to-understand areas (capability contract; fallback caveats; deprecation notes)
- [x] Documentation updated (`doc.go` package-level overview, godoc on all new exports)
- [x] No new warnings / errors
- [x] Read CONTRIBUTING
- [x] Contribution may be redistributed under either [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT)

## Companion PRs (downstream impl)

- **golly-aws#158** (s3 `VFileSystemCtx`) — already open as Draft, depends on this PR
- **golly-gcp#73** (gs `VFileSystemCtx`) — already open as Draft, depends on this PR

Both can opt in to `Lister` and `RangeReader` in follow-ups once this lands.

## Notes on the deferred item

**#2 (Raw / non-Raw collapse)** would halve the `VFileSystem` interface but breaks every external implementation (`golly-aws/s3`, `golly-gcp/gs`, third-party FSes). Per the critique itself: "best done at a major version since it changes the interface." Documented in `doc.go` as a v2 roadmap item. Not in scope here.
