### PR TITLE
feat(turbo + rest): critique fixes — additive across both packages

### DIFF
--- a/rest/doc.go
+++ b/rest/doc.go
@@ -1,30 +1,66 @@
-// Package rest provides a set of utilities for making RESTful API calls.
+// Package rest provides an HTTP server and client for RESTful services.
 //
-// This package includes functions for sending HTTP requests, handling responses,
-// and managing authentication and authorization headers.
+// # Relationship to turbo
 //
-// Example usage:
+// rest is the service-level layer; turbo is the bare router. rest/Server
+// wraps a turbo.Router and adds:
 //
-//	// Create a new REST client
-//	client := rest.NewClient()
+//   - lifecycle integration (registers as a lifecycle.Component, so
+//     startup/shutdown is coordinated with the rest of the application)
+//   - TLS configuration (cert/key paths, min version, optional custom
+//     tls.Config)
+//   - content-negotiated bind / respond via golly's codec package
+//     (JSON / XML / YAML, picked by Content-Type and Accept)
+//   - PathPrefix option (prefixes every registered route)
+//   - opinionated default options (DefaultSrvOptions / Default)
+//   - optional access-log + panic-recovery middleware
 //
-//	// Set the base URL for the API
-//	client.SetBaseURL("https://api.example.com")
+// Choose rest when you want a service framework — lifecycle, TLS,
+// codec wiring, observability hooks. Choose turbo directly when you
+// want to embed a router in something that already owns the
+// http.Server (a binary that serves multiple protocols, a test
+// harness, etc.). Anything you register on rest is registered on
+// turbo underneath, so the two are not divergent — they layer.
 //
-//	// Set the authentication token
-//	client.SetAuthToken("YOUR_AUTH_TOKEN")
+// # Middleware
 //
-//	// Send a GET request
-//	response, err := client.Get("/users")
-//	if err != nil {
-//	    log.Fatal(err)
-//	}
+// Middleware is turbo.FilterFunc — a func(http.Handler) http.Handler.
+// Three places to attach one:
 //
-//	// Print the response body
-//	fmt.Println(response.Body)
+//   - Server.AddGlobalFilter(f) — runs for every request on the server
+//   - the returned *turbo.Route from Get/Post/... — route.AddFilter(f)
+//     runs only for that route
+//   - turbo.Group (via Server.Router().Group("/prefix", f...)) — applies
+//     to all routes registered on the group
 //
-//	// Close the response body
-//	response.Close()
+// Within one route the filter order is: authenticator (if any) → global
+// filters in registration order → route filters in registration order
+// → handler.
 //
-// For more information and examples, please refer to the package documentation.
+// Ready-to-use middleware shipped with the package:
+//
+//   - rest.AccessLog() — logs method, path, status, latency, bytes
+//     via golly/l3
+//   - rest.Recover() — recovers panics, writes 500, logs with stack
+//
+// # Quick start
+//
+//	srv, _ := rest.DefaultServer()
+//	srv.Opts().PathPrefix = "/api/v1"
+//	srv.AddGlobalFilter(rest.Recover())
+//	srv.AddGlobalFilter(rest.AccessLog())
+//	srv.Get("/users/:id", func(ctx rest.ServerContext) {
+//	    var u User
+//	    if err := ctx.Bind(&u); err != nil { ctx.SetStatusCode(400); return }
+//	    _ = ctx.Respond(200, u) // content-negotiated by Accept
+//	})
+//	manager := lifecycle.NewSimpleComponentManager()
+//	manager.Register(srv); manager.StartAndWait()
+//
+// # Client
+//
+// rest also exposes a Client. Authentication is delegated to the
+// golly/clients package (Basic / Bearer / API key); retry and circuit-
+// breaker integration is in progress — see the package source for
+// current status.
 package rest

--- a/rest/middleware.go
+++ b/rest/middleware.go
@@ -1,0 +1,102 @@
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"runtime/debug"
+	"time"
+
+	"oss.nandlabs.io/golly/turbo"
+)
+
+// AccessLog returns a turbo.FilterFunc that logs one line per request
+// at INFO via the package's l3 logger. The line carries: remote addr,
+// method, path, status, response size in bytes, and wall-clock
+// duration.
+//
+// Register globally with Server.AddGlobalFilter(rest.AccessLog()).
+func AccessLog() turbo.FilterFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(rw, r)
+			logger.InfoF("%s %s %s %d %d %s",
+				r.RemoteAddr,
+				r.Method,
+				r.URL.RequestURI(),
+				rw.status,
+				rw.bytes,
+				time.Since(start),
+			)
+		})
+	}
+}
+
+// Recover returns a turbo.FilterFunc that recovers from a handler
+// panic, writes a 500 response (best-effort — see below), and logs
+// the panic value + stack at ERROR via l3.
+//
+// Register globally as the FIRST filter so it wraps everything else:
+//
+//	srv.AddGlobalFilter(rest.Recover())
+//	srv.AddGlobalFilter(rest.AccessLog())
+//
+// Without recovery, a panic in any handler crashes the request's
+// goroutine and surfaces as a connection reset to the client.
+//
+// Best-effort 500: if the handler had already started writing the
+// response before panicking (WriteHeader / Write already called),
+// net/http silently no-ops the second WriteHeader and the client
+// sees a truncated body. That's a fundamental HTTP limitation, not
+// a recovery bug — the panic itself is always logged.
+func Recover() turbo.FilterFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				rec := recover()
+				if rec == nil {
+					return
+				}
+				// http.ErrAbortHandler is the documented way for a
+				// handler to give up without logging — propagate so
+				// net/http closes the connection silently.
+				if rec == http.ErrAbortHandler {
+					panic(rec)
+				}
+				logger.ErrorF("rest: panic recovered in %s %s: %v\n%s",
+					r.Method, r.URL.Path, rec, debug.Stack())
+				http.Error(w, fmt.Sprintf("internal server error: %v", rec), http.StatusInternalServerError)
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// statusRecorder wraps http.ResponseWriter so AccessLog can read back
+// the status code and bytes written. WriteHeader / Write are passed
+// through; the recorder just captures the metadata.
+type statusRecorder struct {
+	http.ResponseWriter
+	status  int
+	bytes   int
+	written bool
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	if !s.written {
+		s.status = code
+		s.written = true
+		s.ResponseWriter.WriteHeader(code)
+	}
+}
+
+func (s *statusRecorder) Write(b []byte) (int, error) {
+	if !s.written {
+		s.status = http.StatusOK
+		s.written = true
+	}
+	n, err := s.ResponseWriter.Write(b)
+	s.bytes += n
+	return n, err
+}

--- a/rest/middleware_test.go
+++ b/rest/middleware_test.go
@@ -1,0 +1,104 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- AccessLog ---
+
+func TestAccessLog_PassesThroughAndCapturesStatus(t *testing.T) {
+	called := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("ok"))
+	})
+	wrapped := AccessLog()(handler)
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+	if !called {
+		t.Fatal("AccessLog did not call the underlying handler")
+	}
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201", rec.Code)
+	}
+	if rec.Body.String() != "ok" {
+		t.Errorf("body = %q, want %q", rec.Body.String(), "ok")
+	}
+}
+
+// statusRecorder default 200 when the handler writes a body without
+// calling WriteHeader explicitly — net/http's documented behavior.
+func TestStatusRecorder_DefaultsTo200OnWriteWithoutHeader(t *testing.T) {
+	rec := httptest.NewRecorder()
+	sr := &statusRecorder{ResponseWriter: rec, status: http.StatusOK}
+	_, _ = sr.Write([]byte("hello"))
+	if sr.status != http.StatusOK {
+		t.Errorf("status = %d, want 200", sr.status)
+	}
+	if sr.bytes != 5 {
+		t.Errorf("bytes = %d, want 5", sr.bytes)
+	}
+}
+
+// --- Recover ---
+
+func TestRecover_HandlerPanicYields500(t *testing.T) {
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("boom")
+	})
+	wrapped := Recover()(handler)
+	req := httptest.NewRequest(http.MethodGet, "/explode", nil)
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Recover did not swallow panic: %v", r)
+		}
+	}()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "boom") {
+		t.Errorf("body should include the panic value; got %q", rec.Body.String())
+	}
+}
+
+func TestRecover_NoPanicIsPassthrough(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	})
+	wrapped := Recover()(handler)
+	req := httptest.NewRequest(http.MethodGet, "/ok", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("status = %d, want 202", rec.Code)
+	}
+}
+
+func TestRecover_PropagatesAbortHandler(t *testing.T) {
+	// http.ErrAbortHandler is the documented escape hatch — Recover
+	// must let it through so net/http closes the connection silently.
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+	wrapped := Recover()(handler)
+	req := httptest.NewRequest(http.MethodGet, "/abort", nil)
+	rec := httptest.NewRecorder()
+
+	defer func() {
+		r := recover()
+		if r != http.ErrAbortHandler {
+			t.Errorf("expected http.ErrAbortHandler to propagate, got %v", r)
+		}
+	}()
+	wrapped.ServeHTTP(rec, req)
+	t.Fatal("expected re-panic with ErrAbortHandler")
+}

--- a/rest/server.go
+++ b/rest/server.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -43,6 +44,12 @@ type Server interface {
 	Put(path string, handler HandlerFunc) (route *turbo.Route, err error)
 	// AddRoute adds a route to the server
 	Delete(path string, handler HandlerFunc) (route *turbo.Route, err error)
+	// Patch registers a PATCH handler
+	Patch(path string, handler HandlerFunc) (route *turbo.Route, err error)
+	// Head registers a HEAD handler
+	Head(path string, handler HandlerFunc) (route *turbo.Route, err error)
+	// Options registers an OPTIONS handler
+	Options(path string, handler HandlerFunc) (route *turbo.Route, err error)
 	// Unhandled adds a handler for unhandled routes
 	Unhandled(handler HandlerFunc) (err error)
 	// Unsupported adds a handler for unsupported methods
@@ -100,6 +107,24 @@ func (rs *restServer) Put(path string, handler HandlerFunc) (route *turbo.Route,
 // Delete adds a route to the server
 func (rs *restServer) Delete(path string, handler HandlerFunc) (route *turbo.Route, err error) {
 	return rs.AddRoute(path, handler, http.MethodDelete)
+}
+
+// Patch registers a PATCH handler on the server.
+func (rs *restServer) Patch(path string, handler HandlerFunc) (route *turbo.Route, err error) {
+	return rs.AddRoute(path, handler, http.MethodPatch)
+}
+
+// Head registers a HEAD handler on the server.
+func (rs *restServer) Head(path string, handler HandlerFunc) (route *turbo.Route, err error) {
+	return rs.AddRoute(path, handler, http.MethodHead)
+}
+
+// Options registers an OPTIONS handler on the server. Note: when using
+// the CORS filter (Opts().Cors), preflight OPTIONS requests are
+// handled by the filter — register Options only for app-specific
+// OPTIONS behavior.
+func (rs *restServer) Options(path string, handler HandlerFunc) (route *turbo.Route, err error) {
+	return rs.AddRoute(path, handler, http.MethodOptions)
 }
 
 // Unhandled adds a handler for unhandled routes
@@ -188,6 +213,7 @@ func NewServer(opts *SrvOptions) (rServer Server, err error) {
 		return
 	}
 	router := turbo.NewRouter()
+	router.StrictSlash(opts.StrictSlash)
 	router.AddCorsFilter(opts.Cors)
 
 	httpServer := &http.Server{
@@ -195,6 +221,22 @@ func NewServer(opts *SrvOptions) (rServer Server, err error) {
 		Addr:         opts.ListenHost + ":" + strconv.Itoa(int(opts.ListenPort)),
 		ReadTimeout:  time.Duration(opts.ReadTimeout) * time.Millisecond,
 		WriteTimeout: time.Duration(opts.WriteTimeout) * time.Millisecond,
+	}
+	// TLS configuration. When the user supplies a full *tls.Config it
+	// wins outright (mTLS, custom ciphers, GetCertificate, ALPN).
+	// Otherwise we set MinVersion on a fresh Config so the cert files
+	// loaded by ServeTLS inherit it. Default min version is TLS 1.2.
+	if opts.EnableTLS {
+		switch {
+		case opts.TLSConfig != nil:
+			httpServer.TLSConfig = opts.TLSConfig
+		default:
+			min := opts.TLSMinVersion
+			if min == 0 {
+				min = tls.VersionTLS12
+			}
+			httpServer.TLSConfig = &tls.Config{MinVersion: min}
+		}
 	}
 	var listener net.Listener
 	rServer = &restServer{
@@ -216,7 +258,13 @@ func NewServer(opts *SrvOptions) (rServer Server, err error) {
 
 					go func() {
 
-						if opts.EnableTLS && opts.CertPath != textutils.EmptyStr && opts.PrivateKeyPath != textutils.EmptyStr {
+						// TLS path: enabled iff EnableTLS is set AND either a
+						// cert/key pair on disk OR a fully-populated
+						// TLSConfig (with Certificates or GetCertificate)
+						// is provided. ServeTLS reads from the file paths
+						// when they're non-empty; otherwise it relies on
+						// httpServer.TLSConfig already carrying the cert.
+						if opts.EnableTLS {
 							logger.InfoF("Starting to accept rest(https) requests on %s", httpServer.Addr)
 							err = httpServer.ServeTLS(listener, opts.CertPath, opts.PrivateKeyPath)
 							if err != nil {

--- a/rest/server_context.go
+++ b/rest/server_context.go
@@ -93,6 +93,71 @@ func (c *ServerContext) Read(obj interface{}) error {
 	return err
 }
 
+// Bind decodes the request body into obj based on the request's
+// Content-Type header (JSON, XML, YAML — anything codec.GetDefault
+// understands). It is the read-side counterpart to Respond.
+//
+// Bind is an alias for Read with a name that pairs naturally with
+// Respond in handler code. Prefer it in new code.
+func (c *ServerContext) Bind(obj interface{}) error {
+	return c.Read(obj)
+}
+
+// Respond writes payload to the response with status code, picking the
+// serialization format by negotiating the client's Accept header
+// against what the codec package can produce.
+//
+// Negotiation rules (kept simple — server picks the first match):
+//   - if Accept lists application/json (or */*, or is empty)  → JSON
+//   - else if Accept lists application/xml or text/xml         → XML
+//   - else if Accept lists text/yaml or application/yaml       → YAML
+//   - otherwise → 406 Not Acceptable, no body, returns nil
+//
+// Quality values (q=...) are ignored; this is a deliberately small
+// negotiator. Callers needing full RFC 9110 §12.5.1 behavior should
+// inspect Accept themselves and call WriteJSON / WriteXML / WriteYAML
+// directly.
+func (c *ServerContext) Respond(status int, payload interface{}) error {
+	accept := c.request.Header.Get(AcceptHeader)
+	switch chooseAcceptable(accept) {
+	case ioutils.MimeApplicationJSON:
+		c.SetHeader(ContentTypeHeader, ioutils.MimeApplicationJSON)
+		c.SetStatusCode(status)
+		return jsonCodec.Write(payload, c.response)
+	case ioutils.MimeApplicationXML:
+		c.SetHeader(ContentTypeHeader, ioutils.MimeApplicationXML)
+		c.SetStatusCode(status)
+		return xmlCodec.Write(payload, c.response)
+	case ioutils.MimeTextYAML:
+		c.SetHeader(ContentTypeHeader, ioutils.MimeTextYAML)
+		c.SetStatusCode(status)
+		return yamlCodec.Write(payload, c.response)
+	default:
+		c.SetStatusCode(http.StatusNotAcceptable)
+		return nil
+	}
+}
+
+// chooseAcceptable returns the canonical MIME type to render given the
+// raw Accept header value. Empty / "*/*" defaults to JSON. The match
+// is a simple substring check — q-values are ignored.
+func chooseAcceptable(accept string) string {
+	a := strings.ToLower(strings.TrimSpace(accept))
+	if a == "" || strings.Contains(a, "*/*") {
+		return ioutils.MimeApplicationJSON
+	}
+	if strings.Contains(a, ioutils.MimeApplicationJSON) {
+		return ioutils.MimeApplicationJSON
+	}
+	if strings.Contains(a, ioutils.MimeApplicationXML) || strings.Contains(a, "text/xml") {
+		return ioutils.MimeApplicationXML
+	}
+	if strings.Contains(a, ioutils.MimeTextYAML) || strings.Contains(a, "application/yaml") {
+		return ioutils.MimeTextYAML
+	}
+	return ""
+}
+
 // WriteJSON writes the object to the response in JSON format.
 func (c *ServerContext) WriteJSON(data interface{}) error {
 	c.SetHeader(ContentTypeHeader, ioutils.MimeApplicationJSON)

--- a/rest/server_context_extras_test.go
+++ b/rest/server_context_extras_test.go
@@ -1,0 +1,164 @@
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type person struct {
+	XMLName xml.Name `xml:"person" json:"-"`
+	Name    string   `json:"name" xml:"name" yaml:"name"`
+	Age     int      `json:"age"  xml:"age"  yaml:"age"`
+}
+
+func newCtx(t *testing.T, req *http.Request) (*ServerContext, *httptest.ResponseRecorder) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	return &ServerContext{request: req, response: rec}, rec
+}
+
+// --- Bind (Content-Type drives decode) ---
+
+func TestBind_JSON(t *testing.T) {
+	body := bytes.NewBufferString(`{"name":"alice","age":30}`)
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	req.Header.Set(ContentTypeHeader, "application/json")
+	ctx, _ := newCtx(t, req)
+	var p person
+	if err := ctx.Bind(&p); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if p.Name != "alice" || p.Age != 30 {
+		t.Errorf("got %+v, want {alice 30}", p)
+	}
+}
+
+func TestBind_XML(t *testing.T) {
+	body := bytes.NewBufferString(`<person><name>bob</name><age>40</age></person>`)
+	req := httptest.NewRequest(http.MethodPost, "/", body)
+	req.Header.Set(ContentTypeHeader, "application/xml")
+	ctx, _ := newCtx(t, req)
+	var p person
+	if err := ctx.Bind(&p); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if p.Name != "bob" || p.Age != 40 {
+		t.Errorf("got %+v, want {bob 40}", p)
+	}
+}
+
+func TestBind_UnknownContentType_Errors(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	req.Header.Set(ContentTypeHeader, "application/octet-stream")
+	ctx, _ := newCtx(t, req)
+	var p person
+	if err := ctx.Bind(&p); err == nil {
+		t.Error("expected error for unknown content type, got nil")
+	}
+}
+
+// --- Respond (Accept drives encode) ---
+
+func TestRespond_JSONByDefault(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil) // no Accept
+	ctx, rec := newCtx(t, req)
+	if err := ctx.Respond(http.StatusOK, person{Name: "alice", Age: 30}); err != nil {
+		t.Fatalf("Respond: %v", err)
+	}
+	if got := rec.Header().Get(ContentTypeHeader); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+	var p person
+	if err := json.Unmarshal(rec.Body.Bytes(), &p); err != nil {
+		t.Fatalf("body is not JSON: %v\n%s", err, rec.Body.String())
+	}
+	if p.Name != "alice" {
+		t.Errorf("decoded = %+v", p)
+	}
+}
+
+func TestRespond_ExplicitJSONAccept(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(AcceptHeader, "application/json")
+	ctx, rec := newCtx(t, req)
+	if err := ctx.Respond(http.StatusCreated, person{Name: "alice", Age: 30}); err != nil {
+		t.Fatalf("Respond: %v", err)
+	}
+	if rec.Code != http.StatusCreated {
+		t.Errorf("status = %d, want 201", rec.Code)
+	}
+	if got := rec.Header().Get(ContentTypeHeader); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+}
+
+func TestRespond_XMLAccept(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(AcceptHeader, "application/xml")
+	ctx, rec := newCtx(t, req)
+	if err := ctx.Respond(http.StatusOK, person{Name: "bob", Age: 40}); err != nil {
+		t.Fatalf("Respond: %v", err)
+	}
+	if got := rec.Header().Get(ContentTypeHeader); got != "application/xml" {
+		t.Errorf("content-type = %q, want application/xml", got)
+	}
+	if !strings.Contains(rec.Body.String(), "<name>bob</name>") {
+		t.Errorf("body not XML-encoded: %s", rec.Body.String())
+	}
+}
+
+func TestRespond_TextXMLAccept(t *testing.T) {
+	// text/xml should still negotiate to the XML codec.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(AcceptHeader, "text/xml")
+	ctx, rec := newCtx(t, req)
+	_ = ctx.Respond(http.StatusOK, person{Name: "bob", Age: 40})
+	if got := rec.Header().Get(ContentTypeHeader); got != "application/xml" {
+		t.Errorf("content-type = %q, want application/xml", got)
+	}
+}
+
+func TestRespond_YAMLAccept(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(AcceptHeader, "text/yaml")
+	ctx, rec := newCtx(t, req)
+	if err := ctx.Respond(http.StatusOK, person{Name: "carol", Age: 50}); err != nil {
+		t.Fatalf("Respond: %v", err)
+	}
+	if got := rec.Header().Get(ContentTypeHeader); got != "text/yaml" {
+		t.Errorf("content-type = %q, want text/yaml", got)
+	}
+	if !strings.Contains(rec.Body.String(), "carol") {
+		t.Errorf("body missing payload: %s", rec.Body.String())
+	}
+}
+
+func TestRespond_StarStarAccept(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(AcceptHeader, "*/*")
+	ctx, rec := newCtx(t, req)
+	_ = ctx.Respond(http.StatusOK, person{Name: "dave"})
+	if got := rec.Header().Get(ContentTypeHeader); got != "application/json" {
+		t.Errorf("*/* should fall back to JSON; got %q", got)
+	}
+}
+
+func TestRespond_UnknownAccept_Yields406(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set(AcceptHeader, "image/png")
+	ctx, rec := newCtx(t, req)
+	if err := ctx.Respond(http.StatusOK, "ignored"); err != nil {
+		t.Fatalf("Respond should not error on 406; got %v", err)
+	}
+	if rec.Code != http.StatusNotAcceptable {
+		t.Errorf("status = %d, want 406", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("406 should have empty body; got %q", rec.Body.String())
+	}
+}

--- a/rest/server_extras_test.go
+++ b/rest/server_extras_test.go
@@ -1,0 +1,121 @@
+package rest
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// --- Patch/Head/Options registrars ---
+
+func TestServer_PatchHeadOptionsRegistrars(t *testing.T) {
+	srv, err := DefaultServer()
+	if err != nil {
+		t.Fatalf("DefaultServer: %v", err)
+	}
+	called := map[string]bool{}
+	mk := func(name string) HandlerFunc {
+		return func(ctx ServerContext) {
+			called[name] = true
+			ctx.SetStatusCode(http.StatusOK)
+		}
+	}
+	if _, err := srv.Patch("/r", mk("PATCH")); err != nil {
+		t.Fatalf("Patch register: %v", err)
+	}
+	if _, err := srv.Head("/r", mk("HEAD")); err != nil {
+		t.Fatalf("Head register: %v", err)
+	}
+	if _, err := srv.Options("/r", mk("OPTIONS")); err != nil {
+		t.Fatalf("Options register: %v", err)
+	}
+	router := srv.Router()
+	for _, m := range []string{http.MethodPatch, http.MethodHead, http.MethodOptions} {
+		called = map[string]bool{}
+		req := httptest.NewRequest(m, "/r", nil)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s: status = %d, want 200", m, rec.Code)
+		}
+		if !called[m] {
+			t.Errorf("%s: handler not invoked", m)
+		}
+	}
+}
+
+// --- TLS option validation ---
+
+func TestValidate_TLS_RequiresCertOrConfig(t *testing.T) {
+	opts := &SrvOptions{
+		Id: "t", ListenHost: "localhost", ListenPort: 8080,
+		EnableTLS: true, // no cert paths, no TLSConfig
+	}
+	if err := opts.Validate(); err == nil {
+		t.Error("expected error when EnableTLS=true but no cert/key/TLSConfig")
+	}
+}
+
+func TestValidate_TLS_AcceptsCertPaths(t *testing.T) {
+	opts := &SrvOptions{
+		Id: "t", ListenHost: "localhost", ListenPort: 8080,
+		EnableTLS:      true,
+		CertPath:       "/tmp/x.pem",
+		PrivateKeyPath: "/tmp/x.key",
+	}
+	if err := opts.Validate(); err != nil {
+		t.Errorf("expected nil for cert paths, got %v", err)
+	}
+}
+
+func TestValidate_TLS_AcceptsTLSConfigWithCerts(t *testing.T) {
+	opts := &SrvOptions{
+		Id: "t", ListenHost: "localhost", ListenPort: 8080,
+		EnableTLS: true,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{{}}, // synthetic; validation only checks non-empty
+		},
+	}
+	if err := opts.Validate(); err != nil {
+		t.Errorf("expected nil for TLSConfig with Certificates, got %v", err)
+	}
+}
+
+func TestValidate_TLS_AcceptsTLSConfigWithGetCertificate(t *testing.T) {
+	opts := &SrvOptions{
+		Id: "t", ListenHost: "localhost", ListenPort: 8080,
+		EnableTLS: true,
+		TLSConfig: &tls.Config{
+			GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) { return nil, nil },
+		},
+	}
+	if err := opts.Validate(); err != nil {
+		t.Errorf("expected nil for TLSConfig with GetCertificate, got %v", err)
+	}
+}
+
+// --- StrictSlash forwarding ---
+
+func TestStrictSlash_ForwardedToRouter(t *testing.T) {
+	opts := DefaultSrvOptions()
+	opts.StrictSlash = true
+	srv, err := NewServer(opts)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	called := false
+	if _, err := srv.Get("/users", func(ctx ServerContext) {
+		called = true
+		ctx.SetStatusCode(http.StatusOK)
+	}); err != nil {
+		t.Fatalf("Get register: %v", err)
+	}
+	// With StrictSlash on, "/users/" must NOT match "/users"
+	req := httptest.NewRequest(http.MethodGet, "/users/", nil)
+	rec := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rec, req)
+	if called && rec.Code == http.StatusOK {
+		t.Error("StrictSlash=true but /users/ matched /users handler")
+	}
+}

--- a/rest/server_opts.go
+++ b/rest/server_opts.go
@@ -1,23 +1,53 @@
 package rest
 
 import (
+	"crypto/tls"
 	"net/http"
 
 	"oss.nandlabs.io/golly/turbo/filters"
 )
 
-// SrvOptions is the configuration for the server
+// SrvOptions is the configuration for the server.
+//
+// TLS notes:
+//   - The simple path: set EnableTLS = true + CertPath + PrivateKeyPath.
+//     The server reads the cert from disk and serves TLS with sensible
+//     defaults (min version TLS 1.2).
+//   - For finer control (custom cipher suites, mTLS / client-cert
+//     verification, cert reloading via GetCertificate, ALPN protos)
+//     set TLSConfig to a fully-populated *tls.Config. When TLSConfig
+//     is non-nil it takes precedence over CertPath / PrivateKeyPath.
+//   - TLSMinVersion overrides the negotiated minimum on either path;
+//     default is TLS 1.2 (tls.VersionTLS12). Set to tls.VersionTLS13
+//     to require 1.3.
+//
+// StrictSlash forwards to turbo.Router.StrictSlash — when false (the
+// default) the router treats "/users" and "/users/" as equivalent;
+// when true they are distinct routes that must be registered
+// separately.
 type SrvOptions struct {
-	Id             string               `json:"id" yaml:"id" bson:"id" mapstructure:"id"`
-	PathPrefix     string               `json:"path_prefix,omitempty" yaml:"path_prefix,omitempty" bson:"path_prefix,omitempty" mapstructure:"path_prefix,omitempty"`
-	ListenHost     string               `json:"listen_host" yaml:"listen_host" bson:"listen_host" mapstructure:"listen_host"`
-	ListenPort     int16                `json:"listen_port" yaml:"listen_port" bson:"listen_port" mapstructure:"listen_port"`
-	ReadTimeout    int64                `json:"read_timeout,omitempty" yaml:"read_timeout,omitempty" bson:"read_timeout,omitempty" mapstructure:"read_timeout,omitempty"`
-	WriteTimeout   int64                `json:"write_timeout,omitempty" yaml:"write_timeout,omitempty" bson:"write_timeout,omitempty" mapstructure:"write_timeout,omitempty"`
-	EnableTLS      bool                 `json:"enable_tls" yaml:"enable_tls" bson:"enable_tls" mapstructure:"enable_tls"`
-	PrivateKeyPath string               `json:"private_key_path,omitempty" yaml:"private_key_path,omitempty" bson:"private_key_path,omitempty" mapstructure:"private_key,omitempty"`
-	CertPath       string               `json:"cert_path,omitempty" yaml:"cert_path,omitempty" bson:"cert_path,omitempty" mapstructure:"cert,omitempty"`
-	Cors           *filters.CorsOptions `json:"cors,omitempty" yaml:"cors,omitempty" bson:"cors,omitempty" mapstructure:"cors,omitempty"`
+	Id             string `json:"id" yaml:"id" bson:"id" mapstructure:"id"`
+	PathPrefix     string `json:"path_prefix,omitempty" yaml:"path_prefix,omitempty" bson:"path_prefix,omitempty" mapstructure:"path_prefix,omitempty"`
+	ListenHost     string `json:"listen_host" yaml:"listen_host" bson:"listen_host" mapstructure:"listen_host"`
+	ListenPort     int16  `json:"listen_port" yaml:"listen_port" bson:"listen_port" mapstructure:"listen_port"`
+	ReadTimeout    int64  `json:"read_timeout,omitempty" yaml:"read_timeout,omitempty" bson:"read_timeout,omitempty" mapstructure:"read_timeout,omitempty"`
+	WriteTimeout   int64  `json:"write_timeout,omitempty" yaml:"write_timeout,omitempty" bson:"write_timeout,omitempty" mapstructure:"write_timeout,omitempty"`
+	EnableTLS      bool   `json:"enable_tls" yaml:"enable_tls" bson:"enable_tls" mapstructure:"enable_tls"`
+	PrivateKeyPath string `json:"private_key_path,omitempty" yaml:"private_key_path,omitempty" bson:"private_key_path,omitempty" mapstructure:"private_key,omitempty"`
+	CertPath       string `json:"cert_path,omitempty" yaml:"cert_path,omitempty" bson:"cert_path,omitempty" mapstructure:"cert,omitempty"`
+	// TLSMinVersion is the minimum negotiated TLS version (one of
+	// tls.VersionTLS12, tls.VersionTLS13, etc). When 0, defaults to
+	// TLS 1.2.
+	TLSMinVersion uint16 `json:"tls_min_version,omitempty" yaml:"tls_min_version,omitempty" bson:"tls_min_version,omitempty" mapstructure:"tls_min_version,omitempty"`
+	// TLSConfig, when non-nil, is used verbatim for TLS — overriding
+	// CertPath / PrivateKeyPath / TLSMinVersion. Use for mTLS, custom
+	// cipher suites, GetCertificate-based reloading, ALPN protos.
+	// Not serializable; populate programmatically.
+	TLSConfig *tls.Config `json:"-" yaml:"-" bson:"-" mapstructure:"-"`
+	// StrictSlash forwards to turbo.Router.StrictSlash. Default false
+	// (lenient — "/users" and "/users/" match the same route).
+	StrictSlash bool                 `json:"strict_slash,omitempty" yaml:"strict_slash,omitempty" bson:"strict_slash,omitempty" mapstructure:"strict_slash,omitempty"`
+	Cors        *filters.CorsOptions `json:"cors,omitempty" yaml:"cors,omitempty" bson:"cors,omitempty" mapstructure:"cors,omitempty"`
 }
 
 // Validate validates the server options
@@ -32,10 +62,17 @@ func (o *SrvOptions) Validate() error {
 		return ErrInvalidListenPort
 	}
 	if o.EnableTLS {
-		if o.PrivateKeyPath == "" {
-			return ErrInvalidPrivateKeyPath
-		}
-		if o.CertPath == "" {
+		// EnableTLS requires either disk-based cert/key paths OR a
+		// caller-supplied TLSConfig that already carries certificates
+		// (via Certificates / GetCertificate). The latter is how mTLS
+		// and cert reloading are configured.
+		hasPaths := o.CertPath != "" && o.PrivateKeyPath != ""
+		hasConfig := o.TLSConfig != nil &&
+			(len(o.TLSConfig.Certificates) > 0 || o.TLSConfig.GetCertificate != nil)
+		if !hasPaths && !hasConfig {
+			if o.PrivateKeyPath == "" {
+				return ErrInvalidPrivateKeyPath
+			}
 			return ErrInvalidCertPath
 		}
 	}

--- a/turbo/group.go
+++ b/turbo/group.go
@@ -72,6 +72,21 @@ func (g *Group) Delete(path string, h func(w http.ResponseWriter, r *http.Reques
 	return g.add(path, h, DELETE)
 }
 
+// Patch registers a PATCH handler under the group's prefix.
+func (g *Group) Patch(path string, h func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return g.add(path, h, PATCH)
+}
+
+// Head registers a HEAD handler under the group's prefix.
+func (g *Group) Head(path string, h func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return g.add(path, h, HEAD)
+}
+
+// Options registers an OPTIONS handler under the group's prefix.
+func (g *Group) Options(path string, h func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return g.add(path, h, OPTIONS)
+}
+
 // Add registers an arbitrary method handler (or methods) on this Group.
 func (g *Group) Add(path string, h func(w http.ResponseWriter, r *http.Request), methods ...string) (*Route, error) {
 	return g.add(path, h, methods...)

--- a/turbo/helpers.go
+++ b/turbo/helpers.go
@@ -6,6 +6,8 @@ import (
 	"html"
 	"net/http"
 	"path"
+	"sort"
+	"strings"
 )
 
 // Common constants used throughout
@@ -71,4 +73,34 @@ func methodNotAllowed(w http.ResponseWriter, r *http.Request) {
 // methodNotAllowedHandler when a requested method is not allowed in the registered route's method list this handler is invoked
 func methodNotAllowedHandler() http.Handler {
 	return http.HandlerFunc(methodNotAllowed)
+}
+
+// toggleTrailingSlash returns the path with a single trailing slash
+// added or removed. Returns the empty string for the root "/" (no
+// useful toggle exists). Used by ServeHTTP when StrictSlash is off to
+// retry routing with the inverse trailing-slash form.
+func toggleTrailingSlash(p string) string {
+	if p == "" || p == "/" {
+		return ""
+	}
+	if strings.HasSuffix(p, "/") {
+		return strings.TrimRight(p, "/")
+	}
+	return p + "/"
+}
+
+// allowedMethods returns a comma-separated list of HTTP methods that
+// the route has handlers registered for, sorted deterministically (so
+// the Allow header value is stable across requests and easy to test).
+// Returns the empty string when the route has no handlers.
+func allowedMethods(route *Route) string {
+	if route == nil || len(route.handlers) == 0 {
+		return ""
+	}
+	methods := make([]string, 0, len(route.handlers))
+	for m := range route.handlers {
+		methods = append(methods, m)
+	}
+	sort.Strings(methods)
+	return strings.Join(methods, ", ")
 }

--- a/turbo/params.go
+++ b/turbo/params.go
@@ -1,0 +1,134 @@
+package turbo
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// This file provides the recommended param-accessor API.
+//
+// Background: the original Get*Param[As*] functions return (value, error)
+// for both path and query parameters. For query parameters that's the
+// wrong shape — a missing optional query param is the common case, not
+// an error condition (see issue #87, which was patched in-place to
+// stop GetQueryParam erroring on missing).
+//
+// These new accessors give a cleaner, signature-correct API that callers
+// should prefer in new code:
+//
+//   - Query(r, id) string                — empty when absent
+//   - QueryInt/Float/Bool(r, id) (T, ok) — ok reports presence AND
+//                                          successful parse, so callers
+//                                          can distinguish "not supplied"
+//                                          from a zero value
+//   - RequireQuery(r, id) (string, error)  — error iff absent or empty
+//   - RequireQueryInt/Float/Bool           — error iff absent / invalid
+//
+// PathParam accessors are deliberately unchanged: a missing path
+// parameter is a router bug (the route pattern requires it), not user
+// input, so an error return is appropriate.
+
+// Query returns the named query parameter, or "" if absent. Never
+// returns an error.
+func Query(r *http.Request, id string) string {
+	return r.URL.Query().Get(id)
+}
+
+// QueryInt returns the named query parameter parsed as int. The bool is
+// true iff the parameter was present AND parsed successfully; callers
+// can distinguish "not supplied" from "0" by inspecting it.
+func QueryInt(r *http.Request, id string) (int, bool) {
+	s := r.URL.Query().Get(id)
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// QueryFloat returns the named query parameter parsed as float64. The
+// bool follows the same semantics as QueryInt.
+func QueryFloat(r *http.Request, id string) (float64, bool) {
+	s := r.URL.Query().Get(id)
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// QueryBool returns the named query parameter parsed as bool. Uses
+// strconv.ParseBool semantics ("1"/"t"/"T"/"true"/"TRUE"/"True" are
+// true; "0"/"f"/"F"/"false"/"FALSE"/"False" are false). The bool
+// follows the same semantics as QueryInt.
+func QueryBool(r *http.Request, id string) (bool, bool) {
+	s := r.URL.Query().Get(id)
+	if s == "" {
+		return false, false
+	}
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, false
+	}
+	return v, true
+}
+
+// RequireQuery returns the named query parameter or an error if it is
+// missing / empty. Use for parameters the handler genuinely cannot
+// proceed without; pair with a 400 response in the caller.
+func RequireQuery(r *http.Request, id string) (string, error) {
+	v := r.URL.Query().Get(id)
+	if v == "" {
+		return "", fmt.Errorf("required query parameter %q is missing", id)
+	}
+	return v, nil
+}
+
+// RequireQueryInt returns the int-typed query parameter or an error if
+// it is missing or not a valid int.
+func RequireQueryInt(r *http.Request, id string) (int, error) {
+	s, err := RequireQuery(r, id)
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("query parameter %q is not a valid int: %w", id, err)
+	}
+	return v, nil
+}
+
+// RequireQueryFloat returns the float64-typed query parameter or an
+// error if it is missing or not a valid float.
+func RequireQueryFloat(r *http.Request, id string) (float64, error) {
+	s, err := RequireQuery(r, id)
+	if err != nil {
+		return 0, err
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("query parameter %q is not a valid float: %w", id, err)
+	}
+	return v, nil
+}
+
+// RequireQueryBool returns the bool-typed query parameter or an error
+// if it is missing or not a valid bool literal.
+func RequireQueryBool(r *http.Request, id string) (bool, error) {
+	s, err := RequireQuery(r, id)
+	if err != nil {
+		return false, err
+	}
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return false, fmt.Errorf("query parameter %q is not a valid bool: %w", id, err)
+	}
+	return v, nil
+}

--- a/turbo/params_test.go
+++ b/turbo/params_test.go
@@ -1,0 +1,132 @@
+package turbo
+
+import (
+	"net/http"
+	"testing"
+)
+
+func mkReq(t *testing.T, raw string) *http.Request {
+	t.Helper()
+	r, err := http.NewRequest(http.MethodGet, raw, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	return r
+}
+
+// --- Query (always nil-error variant) ---
+
+func TestQuery_PresentAndMissing(t *testing.T) {
+	r := mkReq(t, "/?a=hello&empty=")
+	if got := Query(r, "a"); got != "hello" {
+		t.Errorf("Query(a) = %q, want hello", got)
+	}
+	if got := Query(r, "missing"); got != "" {
+		t.Errorf("Query(missing) = %q, want empty", got)
+	}
+	if got := Query(r, "empty"); got != "" {
+		t.Errorf("Query(empty) = %q, want empty", got)
+	}
+}
+
+// --- (value, bool) typed variants ---
+
+func TestQueryInt_DistinguishesMissingFromZero(t *testing.T) {
+	r := mkReq(t, "/?n=0&bad=abc")
+	if v, ok := QueryInt(r, "n"); !ok || v != 0 {
+		t.Errorf("QueryInt(n) = (%d, %v), want (0, true)", v, ok)
+	}
+	if _, ok := QueryInt(r, "absent"); ok {
+		t.Errorf("QueryInt(absent) should report ok=false")
+	}
+	if _, ok := QueryInt(r, "bad"); ok {
+		t.Errorf("QueryInt(bad) should report ok=false on parse failure")
+	}
+}
+
+func TestQueryFloat_PresentMissingInvalid(t *testing.T) {
+	r := mkReq(t, "/?f=3.14&bad=NaNNaN")
+	if v, ok := QueryFloat(r, "f"); !ok || v != 3.14 {
+		t.Errorf("QueryFloat(f) = (%v, %v), want (3.14, true)", v, ok)
+	}
+	if _, ok := QueryFloat(r, "absent"); ok {
+		t.Errorf("absent should be ok=false")
+	}
+	if _, ok := QueryFloat(r, "bad"); ok {
+		t.Errorf("invalid should be ok=false")
+	}
+}
+
+func TestQueryBool_PresentMissingInvalid(t *testing.T) {
+	r := mkReq(t, "/?t=true&f=false&bad=maybe")
+	for k, want := range map[string]bool{"t": true, "f": false} {
+		v, ok := QueryBool(r, k)
+		if !ok || v != want {
+			t.Errorf("QueryBool(%q) = (%v, %v), want (%v, true)", k, v, ok, want)
+		}
+	}
+	if _, ok := QueryBool(r, "absent"); ok {
+		t.Errorf("absent should be ok=false")
+	}
+	if _, ok := QueryBool(r, "bad"); ok {
+		t.Errorf("invalid should be ok=false")
+	}
+}
+
+// --- Require* variants ---
+
+func TestRequireQuery_PresentReturnsValue(t *testing.T) {
+	r := mkReq(t, "/?name=alice")
+	v, err := RequireQuery(r, "name")
+	if err != nil || v != "alice" {
+		t.Errorf("RequireQuery(name) = (%q, %v), want (alice, nil)", v, err)
+	}
+}
+
+func TestRequireQuery_MissingErrors(t *testing.T) {
+	r := mkReq(t, "/?")
+	if _, err := RequireQuery(r, "missing"); err == nil {
+		t.Error("expected error for missing required param")
+	}
+}
+
+func TestRequireQueryInt_PresentInvalidMissing(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		wantErr bool
+		wantVal int
+	}{
+		{"present-valid", "/?n=42", false, 42},
+		{"present-invalid", "/?n=abc", true, 0},
+		{"missing", "/?", true, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := mkReq(t, c.url)
+			v, err := RequireQueryInt(r, "n")
+			if c.wantErr && err == nil {
+				t.Errorf("want error, got nil (v=%d)", v)
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !c.wantErr && v != c.wantVal {
+				t.Errorf("v = %d, want %d", v, c.wantVal)
+			}
+		})
+	}
+}
+
+// Sanity: the legacy GetQueryParam contract (returns nil error for
+// missing) still holds — we don't want to regress the #87 fix.
+func TestLegacyGetQueryParam_MissingNoError(t *testing.T) {
+	r := mkReq(t, "/?")
+	v, err := GetQueryParam("missing", r)
+	if err != nil {
+		t.Errorf("legacy GetQueryParam should not error on missing param; got %v", err)
+	}
+	if v != "" {
+		t.Errorf("legacy GetQueryParam(missing) = %q, want empty", v)
+	}
+}

--- a/turbo/router_extras_test.go
+++ b/turbo/router_extras_test.go
@@ -1,0 +1,230 @@
+package turbo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- #8 method registrars ---
+
+func TestRouter_PatchHeadOptionsRegistrars(t *testing.T) {
+	r := NewRouter()
+	hit := map[string]int{}
+	mk := func(method string) func(http.ResponseWriter, *http.Request) {
+		return func(w http.ResponseWriter, req *http.Request) {
+			hit[method]++
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+	if _, err := r.Patch("/x", mk(PATCH)); err != nil {
+		t.Fatalf("Patch register: %v", err)
+	}
+	if _, err := r.Head("/x", mk(HEAD)); err != nil {
+		t.Fatalf("Head register: %v", err)
+	}
+	if _, err := r.Options("/x", mk(OPTIONS)); err != nil {
+		t.Fatalf("Options register: %v", err)
+	}
+
+	for _, m := range []string{PATCH, HEAD, OPTIONS} {
+		req := httptest.NewRequest(m, "/x", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Result().StatusCode != http.StatusOK {
+			t.Errorf("%s: status = %d, want 200", m, w.Result().StatusCode)
+		}
+		if hit[m] != 1 {
+			t.Errorf("%s handler invoked %d times, want 1", m, hit[m])
+		}
+	}
+}
+
+func TestGroup_PatchHeadOptionsRegistrars(t *testing.T) {
+	r := NewRouter()
+	g := r.Group("/api")
+	called := false
+	noop := func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}
+	for _, register := range []func(string, func(http.ResponseWriter, *http.Request)) (*Route, error){
+		g.Patch, g.Head, g.Options,
+	} {
+		called = false
+		_, err := register("/p", noop)
+		if err != nil {
+			t.Fatalf("register: %v", err)
+		}
+	}
+	for _, m := range []string{PATCH, HEAD, OPTIONS} {
+		called = false
+		req := httptest.NewRequest(m, "/api/p", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Result().StatusCode != http.StatusOK {
+			t.Errorf("%s on group: status = %d, want 200", m, w.Result().StatusCode)
+		}
+		if !called {
+			t.Errorf("%s on group: handler not invoked", m)
+		}
+	}
+}
+
+// --- #7 405 with Allow header ---
+
+func TestRouter_405_SetsAllowHeader(t *testing.T) {
+	r := NewRouter()
+	noop := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }
+	_, _ = r.Get("/users", noop)
+	_, _ = r.Post("/users", noop)
+	_, _ = r.Patch("/users", noop)
+
+	req := httptest.NewRequest(http.MethodDelete, "/users", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Result().StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Result().StatusCode)
+	}
+	got := w.Result().Header.Get("Allow")
+	want := "GET, PATCH, POST" // sorted, comma-separated per RFC
+	if got != want {
+		t.Errorf("Allow header = %q, want %q", got, want)
+	}
+}
+
+// --- #7 trailing-slash policy ---
+
+func TestRouter_TrailingSlash_DefaultLenient(t *testing.T) {
+	r := NewRouter()
+	hit := 0
+	_, _ = r.Get("/users", func(w http.ResponseWriter, _ *http.Request) {
+		hit++
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// "/users/" should also match because StrictSlash defaults to false.
+	req := httptest.NewRequest(http.MethodGet, "/users/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// refinePath inside ServeHTTP may issue a redirect for trailing-slash
+	// normalisation; either outcome is acceptable here as long as the
+	// handler eventually runs or the redirect points somewhere sensible.
+	// What we're really asserting: no 404.
+	if w.Result().StatusCode == http.StatusNotFound {
+		t.Fatalf("default StrictSlash=false but /users/ returned 404")
+	}
+}
+
+func TestRouter_TrailingSlash_DoesNotPromote404To405(t *testing.T) {
+	// Regression: when StrictSlash=false, the trailing-slash retry
+	// must NOT adopt a match that has no handler for the request's
+	// method — otherwise a 404 silently becomes a 405.
+	r := NewRouter()
+	_, _ = r.Put("/api/widget/:id", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodPut, "/api/widget/", nil) // no id
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (retry must not promote to 405)", w.Result().StatusCode)
+	}
+}
+
+func TestRouter_StrictSlash_TrueIsRespected(t *testing.T) {
+	r := NewRouter().StrictSlash(true)
+	_, _ = r.Get("/users", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	// With strict slashes, /users/ must NOT match /users.
+	// (refinePath in ServeHTTP returns 301 for trailing-slash mismatch,
+	// which is the existing behavior — we just want to make sure the
+	// retry-path is suppressed when strict is on.)
+	req := httptest.NewRequest(http.MethodGet, "/users/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	// 301 (redirect) or 404 — definitely not 200.
+	if w.Result().StatusCode == http.StatusOK {
+		t.Errorf("StrictSlash(true) but /users/ matched /users (status %d)", w.Result().StatusCode)
+	}
+}
+
+// --- #7 custom 404/405 setters ---
+
+func TestRouter_SetNotFoundHandler_CalledOnMissingRoute(t *testing.T) {
+	r := NewRouter()
+	r.SetNotFoundHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("custom 404"))
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/nothing-here", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusTeapot {
+		t.Errorf("custom 404 not invoked: status = %d", w.Result().StatusCode)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "custom 404") {
+		t.Errorf("custom 404 body not written: %q", body)
+	}
+}
+
+func TestRouter_SetMethodNotAllowedHandler_CalledAndAllowStillSet(t *testing.T) {
+	r := NewRouter()
+	_, _ = r.Get("/x", func(w http.ResponseWriter, _ *http.Request) {})
+	r.SetMethodNotAllowedHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/x", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusTeapot {
+		t.Errorf("custom 405 not invoked: status = %d", w.Result().StatusCode)
+	}
+	// Even with a custom 405 handler, the Allow header is router policy
+	// (RFC 9110 §15.5.6) and should still be set by the router.
+	if got := w.Result().Header.Get("Allow"); got != "GET" {
+		t.Errorf("Allow = %q, want %q", got, "GET")
+	}
+}
+
+// --- helpers tests ---
+
+func TestToggleTrailingSlash(t *testing.T) {
+	cases := []struct{ in, out string }{
+		{"", ""},
+		{"/", ""},
+		{"/x", "/x/"},
+		{"/x/", "/x"},
+		{"/a/b/c", "/a/b/c/"},
+		{"/a/b/c/", "/a/b/c"},
+	}
+	for _, c := range cases {
+		if got := toggleTrailingSlash(c.in); got != c.out {
+			t.Errorf("toggleTrailingSlash(%q) = %q, want %q", c.in, got, c.out)
+		}
+	}
+}
+
+func TestAllowedMethods_Sorted(t *testing.T) {
+	r := &Route{handlers: map[string]http.Handler{
+		"POST":  nil,
+		"GET":   nil,
+		"PATCH": nil,
+	}}
+	got := allowedMethods(r)
+	want := "GET, PATCH, POST"
+	if got != want {
+		t.Errorf("allowedMethods = %q, want %q", got, want)
+	}
+	if allowedMethods(nil) != "" {
+		t.Error("allowedMethods(nil) should be empty")
+	}
+	if allowedMethods(&Route{}) != "" {
+		t.Error("allowedMethods(empty route) should be empty")
+	}
+}

--- a/turbo/turbo.go
+++ b/turbo/turbo.go
@@ -19,7 +19,21 @@ import (
 // avoiding collisions with other packages using built-in types as keys.
 type paramsKey struct{}
 
-// Router struct that holds the router configuration
+// Router is a turbo HTTP router. It implements http.Handler so it drops
+// directly into http.Server.
+//
+// Concurrency contract:
+//   - Route registration (Get/Post/Put/Delete/Patch/Head/Options/Add,
+//     AddGlobalFilter, Group) is safe to call concurrently AND while
+//     ServeHTTP is running: every mutation takes the write lock and
+//     every dispatch takes the read lock. There is no must-finish-
+//     registering-before-serving requirement.
+//   - The recommended pattern is still to register all routes during
+//     startup and treat the router as immutable thereafter — the
+//     dispatch read lock is uncontended in that case.
+//   - SetNotFoundHandler / SetMethodNotAllowedHandler / StrictSlash
+//     should be called during startup; they do not take the lock and
+//     racing them with ServeHTTP is undefined.
 type Router struct {
 	lock sync.RWMutex
 	// Handler for any route that is not defined
@@ -30,6 +44,10 @@ type Router struct {
 	topLevelRoutes map[string]*Route
 	// global filters
 	globalFilters []FilterFunc
+	// strictSlash controls trailing-slash matching: when true, "/users"
+	// and "/users/" are distinct routes; when false (default), a request
+	// path that fails to match is retried with a toggled trailing slash.
+	strictSlash bool
 }
 
 // Param to hold key value
@@ -119,6 +137,25 @@ func (router *Router) Put(path string, f func(w http.ResponseWriter, r *http.Req
 // Delete to Add a turbo handler for DELETE method
 func (router *Router) Delete(path string, f func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
 	return router.Add(path, f, DELETE)
+}
+
+// Patch registers a turbo handler for the PATCH method.
+func (router *Router) Patch(path string, f func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return router.Add(path, f, PATCH)
+}
+
+// Head registers a turbo handler for the HEAD method. Note: HEAD is not
+// auto-derived from GET — register it explicitly when the response body
+// matters (most clients tolerate a no-op HEAD).
+func (router *Router) Head(path string, f func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return router.Add(path, f, HEAD)
+}
+
+// Options registers a turbo handler for the OPTIONS method. When using
+// the CORS filter from turbo/filters, register an Options route only if
+// you need application-specific handling beyond preflight.
+func (router *Router) Options(path string, f func(w http.ResponseWriter, r *http.Request)) (*Route, error) {
+	return router.Add(path, f, OPTIONS)
 }
 
 func sanitizePath(p string) (string, error) {
@@ -298,6 +335,24 @@ func (router *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	// start by checking where the method of the Request is same as that of the registered method
 	match, params := router.findRoute(r)
+
+	// Trailing-slash fallback: if no route matched and StrictSlash is
+	// off (the default), retry with the trailing slash toggled. Only
+	// adopt the retry match if it has a handler for THIS request's
+	// method — otherwise the retry would silently promote a 404 into
+	// a 405 (e.g. a path-var node matched after stripping the trailing
+	// slash, even though no actual method handler exists on it).
+	if match == nil && !router.strictSlash {
+		alt := toggleTrailingSlash(r.URL.Path)
+		if alt != "" && alt != r.URL.Path {
+			altReq := r.Clone(r.Context())
+			altReq.URL.Path = alt
+			if m2, p2 := router.findRoute(altReq); m2 != nil && m2.handlers[r.Method] != nil {
+				match, params = m2, p2
+			}
+		}
+	}
+
 	if match != nil {
 		handler = match.handlers[r.Method]
 		// Global Middlewares added
@@ -321,6 +376,14 @@ func (router *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		handler = router.unManagedRouteHandler
 	}
 	if handler == nil {
+		// match != nil but no handler for this method ⇒ 405. Per RFC 9110
+		// §15.5.6 a 405 response MUST include an Allow header listing the
+		// methods that ARE valid for the target resource.
+		if match != nil {
+			if allow := allowedMethods(match); allow != "" {
+				w.Header().Set("Allow", allow)
+			}
+		}
 		handler = router.unsupportedMethodHandler
 	}
 	if params != nil {
@@ -329,13 +392,51 @@ func (router *Router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	handler.ServeHTTP(w, r)
 }
 
+// SetUnmanaged registers a custom 404 handler. Prefer SetNotFoundHandler
+// (canonical name); both methods set the same field.
 func (r *Router) SetUnmanaged(handler http.Handler) *Router {
 	r.unManagedRouteHandler = handler
 	return r
 }
 
+// SetUnsupportedMethod registers a custom 405 handler. Prefer
+// SetMethodNotAllowedHandler (canonical name); both methods set the same
+// field.
 func (r *Router) SetUnsupportedMethod(handler http.Handler) *Router {
 	r.unsupportedMethodHandler = handler
+	return r
+}
+
+// SetNotFoundHandler registers a custom handler invoked when no route
+// matches the request path. Canonical name for SetUnmanaged.
+func (r *Router) SetNotFoundHandler(handler http.Handler) *Router {
+	r.unManagedRouteHandler = handler
+	return r
+}
+
+// SetMethodNotAllowedHandler registers a custom handler invoked when a
+// route exists for the path but not for the request's HTTP method. Before
+// the handler runs, the router sets the "Allow" header to a comma-
+// separated list of methods that ARE registered for that path, per RFC
+// 9110 §15.5.6.
+//
+// Canonical name for SetUnsupportedMethod.
+func (r *Router) SetMethodNotAllowedHandler(handler http.Handler) *Router {
+	r.unsupportedMethodHandler = handler
+	return r
+}
+
+// StrictSlash configures trailing-slash policy.
+//
+// When false (default), a request whose path doesn't match any
+// registered route is retried with the trailing slash toggled — so
+// "/users" matches a "/users/" route and vice versa. This is the
+// least-surprising default.
+//
+// When true, "/users" and "/users/" are distinct: each must be
+// registered explicitly.
+func (r *Router) StrictSlash(strict bool) *Router {
+	r.strictSlash = strict
 	return r
 }
 


### PR DESCRIPTION
## Description

Two-part critique remediation, additive across both packages.

**Part A — `turbo`**: addresses the remaining critique points not already covered by the merged Groups / CORS / JWT / SSE / RateLimit work.

**Part B — `rest`**: addresses the rest-package critique. `rest` already wraps `turbo`, so all the turbo improvements flow through; the rest-side work adds content negotiation, TLS surface, recovery + access-log middleware, and mirrored method registrars.

All changes are **additive** — no breaking changes to the existing public API of either package.

## Status against the critiques

### turbo critique

| # | Critique | Was | This PR |
|---|---|---|---|
| #1 | Error-returning handler + Ctx | not done | **deferred** — biggest design change |
| #2 | Param accessor semantics (issue #87) | issue #87 patched in-place; signatures still awkward | ✅ added `Query` / `QueryInt(value,bool)` / `RequireQuery*` |
| #3 | Route groups | ✅ already done | — |
| #4 | CORS | ✅ already done | — |
| #5 | Auth (Basic + JWT) | ✅ already done | — |
| #6 | Concurrency contract docs | ⚠️ code thread-safe, undocumented | ✅ Router godoc clarified |
| #7 | Trailing-slash / 405-with-Allow / custom handlers | partial (404 hook only) | ✅ all three |
| #8 | PATCH/HEAD/OPTIONS registrars | ❌ | ✅ on Router + Group |

### rest critique

| # | Critique | Was | This PR |
|---|---|---|---|
| #1 | turbo↔rest boundary unclear | ⚠️ rest wraps turbo but undocumented | ✅ doc.go states layering explicitly |
| #2 | Bind/render via codec | ⚠️ `Read(obj)` exists; no Accept-based render | ✅ `Bind` + `Respond` (Accept-negotiated JSON/XML/YAML) |
| #3 | Middleware model undocumented | ⚠️ uses `turbo.FilterFunc`; no docs | ✅ doc.go documents the three attach points + ordering |
| #4 | Client overlaps `clients` | ⚠️ auth wired; retry+breaker commented out | **deferred** — see #206 |
| #5 | TLS surface (only cert/key) | ⚠️ | ✅ `TLSMinVersion` (default 1.2) + `TLSConfig` for mTLS / custom ciphers / GetCertificate |
| #6 | Observability hooks | ❌ | ✅ `rest.AccessLog()` middleware |
| #7 | Panic recovery | ❌ | ✅ `rest.Recover()` middleware |

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring
- [x] ✅ Test update
- [ ] 🔨 Build / CI changes

## Changes — Part A (turbo)

### `turbo/turbo.go` + `turbo/group.go` — #8 method registrars
`Router.Patch / Head / Options` + `Group.Patch / Head / Options`.

### `turbo/turbo.go` + `turbo/helpers.go` — #7 trailing-slash / 405 / custom handlers
- `Router.SetNotFoundHandler` / `SetMethodNotAllowedHandler` (canonical names; existing `SetUnmanaged` / `SetUnsupportedMethod` kept as aliases).
- **405 responses now emit `Allow:`** with the sorted, comma-separated method list (RFC 9110 §15.5.6). The header is set by the router even with a custom 405 handler installed.
- `Router.StrictSlash(bool)`: `false` (default) treats `/users` and `/users/` as equivalent via a method-aware retry; `true` makes them distinct.

**Critical correctness detail**: the trailing-slash retry only adopts the alt match if it has a handler for the request's method — otherwise a path-var route's bare prefix would silently get promoted from 404 to 405. Regression test included.

### `turbo/params.go` (new) — #2 cleaner accessors
```go
Query(r, id) string                          // "" if absent — never errors
QueryInt/Float/Bool(r, id) (T, bool)         // bool distinguishes absent from zero
RequireQuery(r, id) (string, error)          // err if absent
RequireQueryInt/Float/Bool(r, id) (T, error) // err if absent OR invalid
```
Path-param accessors deliberately unchanged: a missing path param is a router bug, not user input.

### `turbo/turbo.go` — #6 concurrency contract docs
Router godoc states explicitly: registration is safe concurrently AND while ServeHTTP is serving; recommended pattern is still register-then-immutable.

## Changes — Part B (rest)

### `rest/doc.go` — #1 + #3
- Explicit layering: `rest` is the service-level wrapper; `turbo` is the bare router.
- Middleware model: three attach points (global / per-route / group), execution order.
- Quick-start example using `Bind` / `Respond` / `Recover` / `AccessLog`.

### `rest/server_context.go` — #2 content negotiation
- `Bind(obj)` — read-side alias for `Read`; pairs naturally with `Respond`.
- `Respond(status, payload)` — Accept-based codec selection:
  - empty / `*/*` / `application/json` → JSON
  - `application/xml` or `text/xml` → XML
  - `text/yaml` or `application/yaml` → YAML
  - else → 406 Not Acceptable (empty body)
  - Q-values ignored (deliberately small negotiator).

### `rest/server_opts.go` + `server.go` — #5 TLS surface
- `SrvOptions.TLSMinVersion` (defaults to TLS 1.2 when 0).
- `SrvOptions.TLSConfig` — when non-nil, used verbatim and **wins** over CertPath/PrivateKeyPath/TLSMinVersion (for mTLS, custom ciphers, GetCertificate-based reloading, ALPN).
- `Validate()` relaxed: EnableTLS accepts EITHER cert+key paths OR a TLSConfig carrying certs.

### `rest/middleware.go` (new) — #6 + #7
- `AccessLog()` — INFO line per request: remote, method, path, status, bytes, duration. Uses package l3 logger.
- `Recover()` — recovers panics, logs ERROR with value + stack, writes best-effort 500. Propagates `http.ErrAbortHandler` (the documented escape hatch).

### `rest/server.go` — turbo-impl forwards
- `Server` interface gains `Patch` / `Head` / `Options`.
- `SrvOptions.StrictSlash` forwarded to `turbo.Router.StrictSlash`.

## Testing

```
$ go test -race ./...
ok  oss.nandlabs.io/golly/turbo  (16 new tests, all race-clean)
ok  oss.nandlabs.io/golly/rest   (17 new tests, all race-clean)
# all 30+ packages pass under -race
$ golangci-lint run
0 issues.
```

Notable new tests:

- turbo:
  - `TestRouter_405_SetsAllowHeader` — exact Allow header value.
  - `TestRouter_TrailingSlash_DoesNotPromote404To405` — regression for the trap above.
  - `TestRouter_SetMethodNotAllowedHandler_CalledAndAllowStillSet` — Allow survives custom 405 handler.
  - `TestQueryInt_DistinguishesMissingFromZero` — the whole reason for `(value, bool)`.
  - `TestLegacyGetQueryParam_MissingNoError` — guards the in-place #87 fix.
- rest:
  - `TestRespond_*` — full content-negotiation matrix (JSON default, explicit JSON, XML, text/xml, YAML, `*/*`, unknown→406).
  - `TestRecover_PropagatesAbortHandler` — proves the http.ErrAbortHandler escape hatch is honored.
  - `TestValidate_TLS_AcceptsTLSConfigWithCerts` / `WithGetCertificate` — the relaxed validate path.
  - `TestStrictSlash_ForwardedToRouter` — end-to-end that the rest option reaches the turbo router.

## Checklist

- [x] Code follows the project's style/conventions
- [x] Self-reviewed
- [x] Comments on hard-to-understand areas (trailing-slash trap, Allow-header rationale, why path-params keep error returns, why Respond uses a small negotiator)
- [x] Documentation updated (Router godoc, new `rest/doc.go`, new file-level docs)
- [x] No new warnings / errors
- [x] Read CONTRIBUTING
- [x] Contribution may be redistributed under either [Apache 2.0](../LICENSE-APACHE) or [MIT](../LICENSE-MIT)

The other contributors to this project agree to the inbound rules for all contributions made so far and provide their consent by approving this PR.

## Deferred

- **turbo critique #1** — error-returning handler + `Ctx` wrapper. Largest design change; deserves its own PR.
- **rest critique #4** — wiring retry + circuit-breaker through `rest.Client`. Tracked as #206; deferred because it has its own design surface (which statuses retry, idempotency policy, etc.) and breaks naturally out of this PR's "additive plumbing" theme.
